### PR TITLE
ENH: splitup_InitializeSimulationRun

### DIFF
--- a/src/run.f90
+++ b/src/run.f90
@@ -5031,9 +5031,9 @@ end subroutine InitializeSimulationRunPart1
 
 subroutine InitializeClimate()
     !! Creates the Climate SIM files and reads climate of first day 
+
     ! 10. Climate
     ! create climate files
-
     call CreateDailyClimFiles(GetSimulation_FromDayNr(), &
                GetSimulation_ToDayNr())
     ! climatic data for first day


### PR DESCRIPTION
To have a separate routine to initialize the climate ("InitializeClimate"), InitializeSimulationRun was split into two parts. Between those two parts, the new routine InitializeClimate is called. In LIS this is the moment in which the LIS input is acquired to initialize the climate.