### PR TITLE
HOLD: Optional crop and soil files (only for NASA-LIS-AquaCrop coupling)

### DIFF
--- a/src/global.f90
+++ b/src/global.f90
@@ -7680,24 +7680,19 @@ subroutine LoadProfile(FullName)
     end do
 
     close(fhandle)
-    call LoadProfileProcessing(FullName)
+    call LoadProfileProcessing(VersionNr)
 end subroutine LoadProfile
 
 
-subroutine LoadProfileProcessing(FullName)
+subroutine LoadProfileProcessing(VersionNr)
     !! Further initializations after soil profile attributes have been set
-    !! (e.g. via a call to LoadProfile()). The given file is only read to
-    !! obtain the version number.
-    character(len=*), intent(in) :: FullName
+    !! (e.g. via a call to LoadProfile()).
+    real(dp), intent(in) :: VersionNr
+        !! AquaCrop Version (e.g. 7.0)
 
-    integer(int32) :: i, fhandle
-    real(dp) :: cra_temp, crb_temp, dx_temp, VersionNr
+    integer(int32) :: i
+    real(dp) :: cra_temp, crb_temp, dx_temp
     real(dp), dimension(11) :: saltmob_temp
-
-    open(newunit=fhandle, file=trim(FullName), status='old', action='read')
-    read(fhandle, '(a)')  ! description
-    read(fhandle, *) VersionNr  ! AquaCrop version
-    close(fhandle)
 
     call SetSimulation_SurfaceStorageIni(0.0_dp)
     call SetSimulation_ECStorageIni(0.0_dp)

--- a/src/global.f90
+++ b/src/global.f90
@@ -7632,11 +7632,6 @@ subroutine LoadProfile(FullName)
             call SetSoilLayer_WP(i, WP_temp)
             call SetSoilLayer_InfRate(i, infrate_temp)
             call SetSoilLayer_Description(i, description_temp)
-            ! Default values for Penetrability and Gravel
-            call SetSoilLayer_Penetrability(i, 100_int8)
-            call SetSoilLayer_GravelMass(i, 0_int8)
-            ! determine volume gravel
-            call SetSoilLayer_GravelVol(i, 0._dp)
         else
             if (roundc(VersionNr*10, mold=1) < 60) then
                             ! UPDATE required for Version 6.0
@@ -7651,11 +7646,6 @@ subroutine LoadProfile(FullName)
                 call SetSoilLayer_CRa(i, cra_temp)
                 call SetSoilLayer_CRb(i, crb_temp)
                 call SetSoilLayer_Description(i, description_temp)
-                ! Default values for Penetrability and Gravel
-                call SetSoilLayer_Penetrability(i, 100_int8)
-                call SetSoilLayer_GravelMass(i, 0_int8)
-                ! determine volume gravel
-                call SetSoilLayer_GravelVol(i, 0._dp)
             else
                 read(fhandle, *) thickness_temp, SAT_temp, FC_temp, WP_temp, &
                                  infrate_temp, penetrability_temp, &
@@ -7671,10 +7661,6 @@ subroutine LoadProfile(FullName)
                 call SetSoilLayer_CRa(i, cra_temp)
                 call SetSoilLayer_CRb(i, crb_temp)
                 call SetSoilLayer_Description(i, description_temp)
-                ! determine volume gravel
-                call SetSoilLayer_GravelVol(i, &
-                            FromGravelMassToGravelVolume(GetSoilLayer_SAT(i), &
-                                                    GetSoilLayer_GravelMass(i)))
             end if
         end if
     end do
@@ -7740,6 +7726,24 @@ subroutine LoadProfileProcessing(VersionNr)
                                        cra_temp, crb_temp)
             call SetSoilLayer_CRa(i, cra_temp)
             call SetSoilLayer_CRb(i, crb_temp)
+            ! Default values for Penetrability and Gravel
+            call SetSoilLayer_Penetrability(i, 100_int8)
+            call SetSoilLayer_GravelMass(i, 0_int8)
+            ! determine volume gravel
+            call SetSoilLayer_GravelVol(i, 0._dp)
+        else
+            if (roundc(VersionNr*10, mold=1) < 60) then
+                ! Default values for Penetrability and Gravel
+                call SetSoilLayer_Penetrability(i, 100_int8)
+                call SetSoilLayer_GravelMass(i, 0_int8)
+                ! determine volume gravel
+                call SetSoilLayer_GravelVol(i, 0._dp)
+            else
+                ! determine volume gravel
+                call SetSoilLayer_GravelVol(i, &
+                            FromGravelMassToGravelVolume(GetSoilLayer_SAT(i), &
+                                                    GetSoilLayer_GravelMass(i)))
+            end if
         end if
     end do
 

--- a/src/tempprocessing.f90
+++ b/src/tempprocessing.f90
@@ -38,7 +38,8 @@ use ac_global , only: undef_int, &
                       AdjustOnsetSearchPeriod, &
                       adjustcropyeartoclimfile, &
                       GenerateCO2Description, &
-                      LoadProfile,&
+                      LoadProfile, &
+                      LoadProfileProcessing, &
                       LoadClim, &
                       LoadIrriScheduleInfo,&
                       LoadManagement, &
@@ -2381,7 +2382,9 @@ subroutine LoadSimulationRunProject(NameFileFull, NrRun)
     else
         ! start with load and complete profile description (see 5.) which reset
         ! SWC to FC by default
-        if (GetProfFile() /= '(None)') then
+        if (GetProfFile() == '(None)') then
+            call LoadProfileProcessing(GetProfFilefull())
+        else
             call LoadProfile(GetProfFilefull())
         end if
         call CompleteProfileDescription

--- a/src/tempprocessing.f90
+++ b/src/tempprocessing.f90
@@ -2385,7 +2385,7 @@ subroutine LoadSimulationRunProject(NameFileFull, NrRun)
         ! start with load and complete profile description (see 5.) which reset
         ! SWC to FC by default
         if (GetProfFile() == '(None)') then
-            call LoadProfileProcessing(GetProfFilefull())
+            call LoadProfileProcessing(VersionNr)
         else
             call LoadProfile(GetProfFilefull())
         end if

--- a/src/tempprocessing.f90
+++ b/src/tempprocessing.f90
@@ -2220,8 +2220,13 @@ subroutine LoadSimulationRunProject(NameFileFull, NrRun)
     read(f0, *, iostat=rc) TempString  ! CropFile
     call SetCropFile(trim(TempString))
     read(f0, *, iostat=rc) TempString  ! PathCropFile
-    call SetCropFilefull(trim(TempString)//GetCropFile())
-    call LoadCrop(GetCropFilefull())
+    if (GetCropFile() == '(None)') then
+        call SetCropFilefull(GetCropFile())
+    else
+        call SetCropFilefull(trim(TempString)//GetCropFile())
+        call LoadCrop(GetCropFilefull())
+    end if
+
     ! Adjust crop parameters of Perennials
     if (GetCrop_subkind() == subkind_Forage) then
         ! adjust crop characteristics to the Year (Seeding/Planting or
@@ -2333,7 +2338,11 @@ subroutine LoadSimulationRunProject(NameFileFull, NrRun)
     read(f0, *, iostat=rc) TempString ! ProfFile
     call SetProfFile(trim(TempString))
     read(f0, *, iostat=rc) TempString ! PathProfFile
-    call SetProfFilefull(trim(TempString)//GetProfFile())
+    if (GetProfFile() == '(None)') then
+        call SetProfFilefull(GetProfFile())
+    else
+        call SetProfFilefull(trim(TempString)//GetProfFile())
+    end if
     ! The load of profile is delayed to check if soil water profile need to be
     ! reset (see 8.)
 
@@ -2372,7 +2381,9 @@ subroutine LoadSimulationRunProject(NameFileFull, NrRun)
     else
         ! start with load and complete profile description (see 5.) which reset
         ! SWC to FC by default
-        call LoadProfile(GetProfFilefull())
+        if (GetProfFile() /= '(None)') then
+            call LoadProfile(GetProfFilefull())
+        end if
         call CompleteProfileDescription
 
         ! Adjust size of compartments if required

--- a/src/tempprocessing.f90
+++ b/src/tempprocessing.f90
@@ -251,7 +251,8 @@ use ac_global , only: undef_int, &
                       setrainrecord,&
                       setobservationsdescription,&
                       adjustclimrecordto,&
-                      loadcrop,&
+                      LoadCrop, &
+                      LoadCropProcessing, &
                       setsimulation_todaynr,&
                       noirrigation,&
                       setsimulation_thetaini_i,&
@@ -2223,6 +2224,7 @@ subroutine LoadSimulationRunProject(NameFileFull, NrRun)
     read(f0, *, iostat=rc) TempString  ! PathCropFile
     if (GetCropFile() == '(None)') then
         call SetCropFilefull(GetCropFile())
+        call LoadCropProcessing()
     else
         call SetCropFilefull(trim(TempString)//GetCropFile())
         call LoadCrop(GetCropFilefull())


### PR DESCRIPTION
This PR intends to make 'crop' and 'soil' files optional (by specifying them as `(None)` in the PRM/PRO file)
and in this way allow external programs like LIS to set crop- and soil-related parameters directly
(without needing to write input files which would then be read in by AquaCrop).

- [x] Passes the Perennial and Harvest tests and a selection of ~50 Europe tests, for the combinations
`DEBUG=0/FORTRAN_EXE=1`, `DEBUG=1/FORTRAN_EXE=1` and  `DEBUG=1/FORTRAN_EXE=0`,
 both with the Singularity image and with `foss-2018a.
- [x] Split up LoadCrop procedure as well.
- [x] Re-run above tests (all passed)
- [ ] Test with LIS (-> Michel)