### PR TITLE
ENH: first usage of use_default_crop_file to avoid redundant saving

### DIFF
--- a/src/defaultcropsoil.f90
+++ b/src/defaultcropsoil.f90
@@ -137,7 +137,9 @@ implicit none
 contains
 
 
-subroutine ResetDefaultCrop()
+subroutine ResetDefaultCrop(use_default_crop_file)
+    logical, intent(in) :: use_default_crop_file
+        !! Whether to write a 'DEFAULT.CRO' file.
 
     call SetCropDescription('a generic crop')
     call SetCrop_subkind(subkind_Grain)
@@ -277,9 +279,10 @@ subroutine ResetDefaultCrop()
                                              ! to root system at end of season
     call SetCrop_Assimilates_Mobilized(0_int8) ! Percentage stored assimilates,
                                     ! transferred to above ground parts in next season
-
-    call SetCropFilefull(GetPathNameSimul() // 'DEFAULT.CRO')
-    call SaveCrop(GetCropFilefull())
+    if (use_default_crop_file) then
+        call SetCropFilefull(GetPathNameSimul() // 'DEFAULT.CRO')
+        call SaveCrop(GetCropFilefull())
+    end if
 end subroutine ResetDefaultCrop
 
 

--- a/src/initialsettings.f90
+++ b/src/initialsettings.f90
@@ -198,8 +198,9 @@ implicit none
 contains
 
 
-subroutine InitializeSettings(use_default_soil_file)
+subroutine InitializeSettings(use_default_soil_file,use_default_crop_file)
     logical, intent(in) :: use_default_soil_file
+    logical, intent(in) :: use_default_crop_file
         !! Whether to make use of a 'DEFAULT.sol' soil file.
 
     character(len=1025) :: TempString1, TempString2, CO2descr
@@ -344,7 +345,7 @@ subroutine InitializeSettings(use_default_soil_file)
 
 
     ! 3. Crop characteristics and cropping period
-    call ResetDefaultCrop ! Reset the crop to its default values
+    call ResetDefaultCrop(use_default_crop_file) ! Reset the crop to its default values
     call SetCropFile('DEFAULT.CRO')
     call SetCropFilefull(GetPathNameSimul() // GetCropFile())
     ! LoadCrop ==============================

--- a/src/interface_defaultcropsoil.f90
+++ b/src/interface_defaultcropsoil.f90
@@ -1,6 +1,7 @@
 module ac_interface_defaultcropsoil
 
-use ac_defaultcropsoil, only: ResetDefaultSoil
+use ac_defaultcropsoil, only: ResetDefaultSoil,&
+                              ResetDefaultCrop
 implicit none
 
 
@@ -15,5 +16,14 @@ subroutine ResetDefaultSoil_wrap(use_default_soil_file)
     use_default_soil_file_f = use_default_soil_file
     call ResetDefaultSoil(use_default_soil_file_f)
 end subroutine ResetDefaultSoil_wrap
+
+subroutine ResetDefaultCrop_wrap(use_default_crop_file)
+    logical(1), intent(in) :: use_default_crop_file
+
+    logical :: use_default_crop_file_f
+
+    use_default_crop_file_f = use_default_crop_file
+    call ResetDefaultCrop(use_default_crop_file_f)
+end subroutine ResetDefaultCrop_wrap
 
 end module ac_interface_defaultcropsoil

--- a/src/interface_defaultcropsoil.pas
+++ b/src/interface_defaultcropsoil.pas
@@ -4,8 +4,8 @@ unit interface_defaultcropsoil;
 interface
 
 
-procedure ResetDefaultCrop;
-    external 'aquacrop' name '__ac_defaultcropsoil_MOD_resetdefaultcrop';
+procedure ResetDefaultCrop(constref use_default_crop_file : boolean);
+    external 'aquacrop' name '__ac_interface_defaultcropsoil_MOD_resetdefaultcrop_wrap';
 
 procedure ResetDefaultSoil(constref use_default_soil_file : boolean);
     external 'aquacrop' name '__ac_interface_defaultcropsoil_MOD_resetdefaultsoil_wrap';

--- a/src/interface_initialsettings.f90
+++ b/src/interface_initialsettings.f90
@@ -7,13 +7,16 @@ implicit none
 contains
 
 
-subroutine InitializeSettings_wrap(use_default_soil_file)
+subroutine InitializeSettings_wrap(use_default_soil_file,use_default_crop_file)
     logical(1), intent(in) :: use_default_soil_file
+    logical(1), intent(in) :: use_default_crop_file
 
     logical :: use_default_soil_file_f
+    logical :: use_default_crop_file_f
 
     use_default_soil_file_f = use_default_soil_file
-    call InitializeSettings(use_default_soil_file_f)
+    use_default_crop_file_f = use_default_crop_file
+    call InitializeSettings(use_default_soil_file_f,use_default_crop_file_f)
 end subroutine InitializeSettings_wrap
 
 end module ac_interface_initialsettings

--- a/src/startunit.F90
+++ b/src/startunit.F90
@@ -557,7 +557,8 @@ subroutine InitializeProject(iproject, TheProjectFile, TheProjectType)
     if ((TheProjectType /= typeproject_TypeNone) .and. CanSelect) then
         ! run the project after cheking environment and simumation files
         ! 1. Set No specific project
-        call InitializeSettings(use_default_soil_file=.true.)
+        call InitializeSettings(use_default_soil_file=.true., &
+                                use_default_crop_file=.true.)
 
         select case(TheProjectType)
         case(typeproject_TypePRO)


### PR DESCRIPTION
This PR adds the use_default_crop_file option.
By default use_default_crop_file is .true. and causing zero diff with current Aquacrop version.
By setting use_default_crop_file to .false., the option currently only omits the saving of the file DEFAULT.CRO.
When calling AC externally from LIS, this saves the saving of n_grid_cells x ens_members of savings to hard disk. Initialization of larger domains and OL runs is reduced from several hours to a few minutes.
Small Perennial and Europe tests passed.