### PR TITLE
ENH: V71 release changes

### DIFF
--- a/src/global.f90
+++ b/src/global.f90
@@ -5605,7 +5605,7 @@ real(dp) function HarvestIndexDay(DAP, DaysToFlower, HImax, dHIdt, CCi, &
         tMax = roundc(HImax/dHIdt_local, mold=1)
         if ((HIfinal == HImax) .and. (t <= tmax) &
                               .and. (CCi <= (PercCCxHIfinal/100._dp)) &
-                              .and. (TheCCxWithered > 0._dp) &
+                              .and. (TheCCxWithered > epsilon(0._dp)) &
                               .and. (CCi < TheCCxWithered) &
                               .and. (GetCrop_subkind() /= subkind_Vegetative) &
                               .and. (GetCrop_subkind() /= subkind_Forage)) then

--- a/src/global.f90
+++ b/src/global.f90
@@ -420,8 +420,6 @@ type rep_Cuttings
         !! Undocumented
     integer(int32) :: CCcut
         !! Canopy cover (%) after cutting
-    integer(int32) :: CGCPlus
-        !! Increase (percentage) of CGC after cutting
     integer(int32) :: Day1
         !! first day after time window for generating cuttings (1 = start crop cycle)
     integer(int32) :: NrDays
@@ -912,6 +910,23 @@ type rep_PerennialPeriod
         !! Undocumented
 end type rep_PerennialPeriod
 
+type rep_FileOK
+    logical :: Climate_Filename
+    logical :: Temperature_Filename
+    logical :: ETo_Filename
+    logical :: Rain_Filename
+    logical :: CO2_Filename
+    logical :: Calendar_Filename
+    logical :: Crop_Filename
+    logical :: Irrigation_Filename
+    logical :: Management_Filename
+    logical :: GroundWater_Filename
+    logical :: Soil_Filename
+    logical :: SWCIni_Filename
+    logical :: OffSeason_Filename
+    logical :: Observations_Filename
+end type rep_FileOK
+    
 character(len=:), allocatable :: RainFile
 character(len=:), allocatable :: RainFileFull
 character(len=:), allocatable :: RainDescription
@@ -3323,7 +3338,6 @@ subroutine NoManagement()
     ! multiple cuttings
     call SetManagement_Cuttings_Considered(.false.)
     call SetManagement_Cuttings_CCcut(30)
-    call SetManagement_Cuttings_CGCPlus(20)
     call SetManagement_Cuttings_Day1(1)
     call SetManagement_Cuttings_NrDays(undef_int)
     call SetManagement_Cuttings_Generate(.false.)
@@ -3421,8 +3435,8 @@ subroutine LoadManagement(FullName)
         end if
         read(fhandle, *) TempInt  ! Canopy cover (%) after cutting
         call SetManagement_Cuttings_CCcut(TempInt)
+        ! Next line NO LONGER CONSIDERED since AquaCrop version 7.1
         read(fhandle, *) TempInt ! Increase (percentage) of CGC after cutting
-        call SetManagement_Cuttings_CGCPlus(TempInt)
         read(fhandle, *) TempInt ! Considered first day when generating cuttings
                                  ! (1 = start of growth cycle)
         call SetManagement_Cuttings_Day1(TempInt)
@@ -3469,7 +3483,6 @@ subroutine LoadManagement(FullName)
     else
         call SetManagement_Cuttings_Considered(.false.)
         call SetManagement_Cuttings_CCcut(30)
-        call SetManagement_Cuttings_CGCPlus(20)
         call SetManagement_Cuttings_Day1(1)
         call SetManagement_Cuttings_NrDays(undef_int)
         call SetManagement_Cuttings_Generate(.false.)
@@ -5514,7 +5527,8 @@ end function SeasonalSumOfKcPot
 
 
 real(dp) function HarvestIndexDay(DAP, DaysToFlower, HImax, dHIdt, CCi, &
-                                  CCxadjusted, PercCCxHIfinal, TempPlanting, &
+                                  CCxadjusted, TheCCxWithered, &
+                                  PercCCxHIfinal, TempPlanting, &
                                   PercentLagPhase, HIfinal)
     integer(int32), intent(in) :: DAP
     integer(int32), intent(in) :: DaysToFlower
@@ -5522,6 +5536,7 @@ real(dp) function HarvestIndexDay(DAP, DaysToFlower, HImax, dHIdt, CCi, &
     real(dp), intent(in) :: dHIdt
     real(dp), intent(in) :: CCi
     real(dp), intent(in) :: CCxadjusted
+    real(dp), intent(in) :: TheCCxWithered
     integer(int8), intent(in) :: PercCCxHIfinal
     integer(intEnum), intent(in) :: TempPlanting
     integer(int8), intent(inout) :: PercentLagPhase
@@ -5590,6 +5605,8 @@ real(dp) function HarvestIndexDay(DAP, DaysToFlower, HImax, dHIdt, CCi, &
         tMax = roundc(HImax/dHIdt_local, mold=1)
         if ((HIfinal == HImax) .and. (t <= tmax) &
                               .and. (CCi <= (PercCCxHIfinal/100._dp)) &
+                              .and. (TheCCxWithered > 0._dp) &
+                              .and. (CCi < TheCCxWithered) &
                               .and. (GetCrop_subkind() /= subkind_Vegetative) &
                               .and. (GetCrop_subkind() /= subkind_Forage)) then
             HIfinal = roundc(HIday, mold=1)
@@ -7173,32 +7190,50 @@ subroutine LoadProjectDescription(DescriptionOfProject)
 end subroutine LoadProjectDescription
 
 
-subroutine CheckFilesInProject(Runi, AllOK)
+subroutine CheckFilesInProject(Runi, AllOK, FileOK)
     integer(int32), intent(in) :: Runi
     logical, intent(out) :: AllOK
+    type(rep_FileOK), intent(out) :: FileOK
 
+    logical :: FileOK_tmp
+    
     AllOK = .true.
+    FileOK_tmp = .true.
 
     ! Check the 14 files
     associate(input => ProjectInput(Runi))
     call check_file(input%Climate_Directory, input%Climate_Filename)
+    FileOK%Climate_Filename = FileOK_tmp
     call check_file(input%Temperature_Directory, input%Temperature_Filename)
+    FileOK%Temperature_Filename = FileOK_tmp
     call check_file(input%ETo_Directory, input%ETo_Filename)
+    FileOK%ETo_Filename = FileOK_tmp
     call check_file(input%Rain_Directory, input%Rain_Filename)
+    FileOK%Rain_Filename = FileOK_tmp
     call check_file(input%CO2_Directory, input%CO2_Filename)
+    FileOK%CO2_Filename = FileOK_tmp
     call check_file(input%Calendar_Directory, input%Calendar_Filename)
+    FileOK%Calendar_Filename = FileOK_tmp
     call check_file(input%Crop_Directory, input%Crop_Filename)
+    FileOK%Crop_Filename = FileOK_tmp
     call check_file(input%Irrigation_Directory, input%Irrigation_Filename)
+    FileOK%Irrigation_Filename = FileOK_tmp
     call check_file(input%Management_Directory, input%Management_Filename)
+    FileOK%Management_Filename = FileOK_tmp
     call check_file(input%GroundWater_Directory, input%GroundWater_Filename)
+    FileOK%GroundWater_Filename = FileOK_tmp
     call check_file(input%Soil_Directory, input%Soil_Filename)
+    FileOK%Soil_Filename = FileOK_tmp
 
     if (ProjectInput(Runi)%SWCIni_Filename /= 'KeepSWC') then
         call check_file(input%SWCIni_Directory, input%SWCIni_Filename)
+        FileOK%SWCIni_Filename = FileOK_tmp
     end if
 
     call check_file(input%OffSeason_Directory, input%OffSeason_Filename)
+    FileOK%OffSeason_Filename = FileOK_tmp
     call check_file(input%Observations_Directory, input%Observations_Filename)
+    FileOK%Observations_Filename = FileOK_tmp
     end associate
 
 
@@ -7213,6 +7248,9 @@ subroutine CheckFilesInProject(Runi, AllOK)
         if (filename /= '(None)') then
             if (.not. FileExists(directory // filename)) then
                 AllOK = .false.
+                FileOK_tmp = .false.
+            else
+                FileOK_tmp = .true.
             end if
         end if
     end subroutine check_file
@@ -9195,13 +9233,6 @@ integer(int32) function GetManagement_Cuttings_CCcut()
 end function GetManagement_Cuttings_CCcut
 
 
-integer(int32) function GetManagement_Cuttings_CGCPlus()
-    !! Getter for the "Cuttings" global variable.
-
-    GetManagement_Cuttings_CGCPlus = Cuttings%CGCPlus
-end function GetManagement_Cuttings_CGCPlus
-
-
 integer(int32) function GetManagement_Cuttings_Day1()
     !! Getter for the "Cuttings" global variable.
 
@@ -9266,14 +9297,6 @@ subroutine SetManagement_Cuttings_CCcut(CCcut)
 
     Cuttings%CCcut = CCcut
 end subroutine SetManagement_Cuttings_CCcut
-
-
-subroutine SetManagement_Cuttings_CGCPlus(CGCPlus)
-    !! Setter for the "Cuttings" global variable.
-    integer(int32), intent(in) :: CGCPlus
-
-    Cuttings%CGCPlus = CGCPlus
-end subroutine SetManagement_Cuttings_CGCPlus
 
 
 subroutine SetManagement_Cuttings_Day1(Day1)
@@ -16204,5 +16227,6 @@ subroutine SetPart2Eval(Part2Eval_in)
 
     Part2Eval = Part2Eval_in
 end subroutine SetPart2Eval
+
 
 end module ac_global

--- a/src/global.f90
+++ b/src/global.f90
@@ -3435,7 +3435,8 @@ subroutine LoadManagement(FullName)
         end if
         read(fhandle, *) TempInt  ! Canopy cover (%) after cutting
         call SetManagement_Cuttings_CCcut(TempInt)
-        ! Next line NO LONGER CONSIDERED since AquaCrop version 7.1
+        ! Next line is expected to be present in the input file, however
+        ! A PARAMETER THAT IS NO LONGER USED since AquaCrop version 7.1
         read(fhandle, *) TempInt ! Increase (percentage) of CGC after cutting
         read(fhandle, *) TempInt ! Considered first day when generating cuttings
                                  ! (1 = start of growth cycle)

--- a/src/interface_global.f90
+++ b/src/interface_global.f90
@@ -243,7 +243,8 @@ use ac_global, only: CheckFilesInProject, &
                      GetPart1Mult, &
                      GetPart2Eval, &
                      SetPart1Mult, &
-                     SetPart2Eval
+                     SetPart2Eval, &
+                     rep_FileOK
 use ac_kinds, only: dp, &
                     int32, &
                     intEnum, &
@@ -420,15 +421,18 @@ subroutine LoadProjectDescription_wrap(DescriptionOfProject, strlen)
 end subroutine LoadProjectDescription_wrap
 
 
-subroutine CheckFilesInProject_wrap(Runi, AllOK)
+subroutine CheckFilesInProject_wrap(Runi, AllOK, FileOK)
     !! Wrapper for [[ac_global:CheckFilesInProject]] for foreign languages.
     integer(int32), intent(in) :: Runi
     logical(1), intent(out) :: AllOK
+    type(rep_FileOK), intent(out) :: FileOK
 
     logical :: AllOK_f
+    type(rep_FileOK) :: FileOK_f
 
-    call CheckFilesInProject(Runi, AllOK_f)
+    call CheckFilesInProject(Runi, AllOK_f, FileOK_f)
     AllOK = AllOK_f
+    FileOK = FileOK_f
 end subroutine CheckFilesInProject_wrap
 
 

--- a/src/interface_global.pas
+++ b/src/interface_global.pas
@@ -4326,6 +4326,7 @@ function __SeasonalSumOfKcPot(constref TheDaysToCCini,TheGDDaysToCCini : integer
 function HarvestIndexDay(constref DAP  : LongInt;
                          constref DaysToFlower,HImax : integer;
                          constref dHIdt,CCi,CCxadjusted : double;
+                         constref TheCCxWithered : double;
                          constref PercCCxHIfinal        : ShortInt;
                          constref TempPlanting : rep_Planting;
                          var PercentLagPhase : ShortInt;
@@ -4334,6 +4335,7 @@ function HarvestIndexDay(constref DAP  : LongInt;
 function __HarvestIndexDay(constref DAP  : LongInt;
                          constref DaysToFlower,HImax : integer;
                          constref dHIdt,CCi,CCxadjusted : double;
+                         constref TheCCxWithered : double;
                          constref PercCCxHIfinal        : ShortInt;
                          constref int_planting : integer;
                          var PercentLagPhase : ShortInt;
@@ -4919,6 +4921,7 @@ end;
 function HarvestIndexDay(constref DAP  : LongInt;
                          constref DaysToFlower,HImax : integer;
                          constref dHIdt,CCi,CCxadjusted : double;
+                         constref TheCCxWithered : double;
                          constref PercCCxHIfinal        : ShortInt;
                          constref TempPlanting : rep_Planting;
                          var PercentLagPhase : ShortInt;
@@ -4928,7 +4931,7 @@ var
 begin
     int_planting := ord(TempPlanting);
     HarvestIndexDay := __HarvestIndexDay(DAP, DaysToFlower, HImax, dHIdt,
-                                         CCi, CCxadjusted, PercCCxHIfinal,
+                                         CCi, CCxadjusted, TheCCxWithered, PercCCxHIfinal,
                                          int_planting, PercentLagPhase,
                                          HIfinal);
 end;

--- a/src/interface_global.pas
+++ b/src/interface_global.pas
@@ -24,6 +24,7 @@ type
 
     rep_string25 = string[25]; (* Description SoilLayer *)
     repstring17 = string[17]; (* Date string *)
+    rep_CheckFileArray = ARRAY[1..14] of Boolean;
 
     rep_salt = ARRAY[1..11] of double; (* saltcontent in g/m2 *)
 
@@ -192,7 +193,6 @@ type
      rep_Cuttings = Record
          Considered : BOOLEAN;
          CCcut      : Integer; // Canopy cover (%) after cutting
-         CGCPlus    : Integer; // Increase (percentage) of CGC after cutting
          Day1       : Integer; // first day after time window for generating cuttings (1 = start crop cycle)
          NrDays     : Integer; // number of days of time window for generate cuttings (-9 is whole crop cycle)
          Generate   : Boolean; // ture: generate cuttings; false : schedule for cuttings
@@ -472,6 +472,22 @@ type
 
     repTypeProject = (TypePRO,TypePRM,TypeNone);
 
+    rep_FileOK = Record
+        Climate_Filename          : Boolean;
+        Temperature_Filename      : Boolean;
+        ETo_Filename              : Boolean;
+        Rain_Filename             : Boolean;
+        CO2_Filename              : Boolean;
+        Calendar_Filename         : Boolean;
+        Crop_Filename             : Boolean;
+        Irrigation_Filename       : Boolean;
+        Management_Filename       : Boolean;
+        GroundWater_Filename      : Boolean;
+        Soil_Filename             : Boolean;
+        SWCIni_Filename           : Boolean;
+        OffSeason_Filename        : Boolean;
+        Observations_Filename     : Boolean;
+        end;
 
 function DeduceAquaCropVersion(FullNameXXFile : string) : double;
          external 'aquacrop' name '__ac_global_MOD_deduceaquacropversion';
@@ -1917,7 +1933,6 @@ procedure SetSimulParam_EffectiveRain_ShowersInDecade(constref ShowersInDecade :
 procedure SetSimulParam_EffectiveRain_RootNrEvap(constref RootNrEvap : shortint);
     external 'aquacrop' name '__ac_global_MOD_getsimulparam_effectiverain_rootnrevap';
 
-
 function GetPathNameProg(): string;
 
 function GetPathNameProg_wrap(): PChar;
@@ -2383,7 +2398,8 @@ procedure LoadProjectDescription_wrap(
 
 procedure CheckFilesInProject(
             constref Runi : integer;
-            out AllOK : boolean);
+            out AllOK : boolean;
+            out FileOK : rep_FileOK);
         external 'aquacrop' name '__ac_interface_global_MOD_checkfilesinproject_wrap';
 
 function GetIrriECw(): rep_IrriECw;
@@ -2397,9 +2413,6 @@ procedure SetIrriECw_PostSeason(constref PostSeason : double);
 
 function GetManagement_Cuttings_Considered(): boolean;
         external 'aquacrop' name '__ac_interface_global_MOD_getmanagement_cuttings_considered_wrap';
-
-function GetManagement_Cuttings_CGCPlus(): integer;
-        external 'aquacrop' name '__ac_global_MOD_getmanagement_cuttings_cgcplus';
 
 function GetManagement_Cuttings_CCcut(): integer;
         external 'aquacrop' name '__ac_global_MOD_getmanagement_cuttings_cccut';
@@ -2429,9 +2442,6 @@ procedure SetManagement_Cuttings_Considered(constref Considered : boolean);
 
 procedure SetManagement_Cuttings_CCcut(constref CCcut : integer);
         external 'aquacrop' name '__ac_global_MOD_setmanagement_cuttings_cccut';
-
-procedure SetManagement_Cuttings_CGCPlus(constref CGCPlus : integer);
-        external 'aquacrop' name '__ac_global_MOD_setmanagement_cuttings_cgcplus';
 
 procedure SetManagement_Cuttings_Day1(constref Day1 : integer);
         external 'aquacrop' name '__ac_global_MOD_setmanagement_cuttings_day1';

--- a/src/interface_run.f90
+++ b/src/interface_run.f90
@@ -61,8 +61,6 @@ use ac_run, only:   CheckForPrint, &
                     SetStartMode, &
                     GetNoMoreCrop, &
                     SetNoMoreCrop, &
-                    GetCGCadjustmentAfterCutting, &
-                    SetCGCadjustmentAfterCutting, &
                     WriteSimPeriod, &
                     WriteIntermediatePeriod, &
                     InitializeTransferAssimilates, &
@@ -656,24 +654,6 @@ subroutine SetNoMoreCrop_wrap(NoMoreCrop_in)
 end subroutine SetNoMoreCrop_wrap
 
 
-function GetCGCadjustmentAfterCutting_wrap() result(CGCadjustmentAfterCutting_f)
-
-    logical(1) :: CGCadjustmentAfterCutting_f
-
-    CGCadjustmentAfterCutting_f = GetCGCadjustmentAfterCutting()
-end function GetCGCadjustmentAfterCutting_wrap
-
-
-subroutine SetCGCadjustmentAfterCutting_wrap(CGCadjustmentAfterCutting_in)
-    logical(1), intent(in) :: CGCadjustmentAfterCutting_in
-
-    logical :: CGCadjustmentAfterCutting_f
-
-    CGCadjustmentAfterCutting_f = CGCadjustmentAfterCutting_in
-    call SetCGCadjustmentAfterCutting(CGCadjustmentAfterCutting_f)
-end subroutine SetCGCadjustmentAfterCutting_wrap
-
-
 function GetTheProjectFile_wrap() result(c_pointer)
     !! Wrapper for [[ac_run:GetTheProjectFile]] for foreign languages.
     type(c_ptr) :: c_pointer
@@ -737,7 +717,8 @@ end subroutine WriteIntermediatePeriod_wrap
 
 subroutine InitializeTransferAssimilates_wrap(Bin, Bout, AssimToMobilize, &
                                          AssimMobilized, FracAssim, &
-                                         StorageON, MobilizationON)
+                                         StorageON, MobilizationON, &
+                                         HarvestNow)
     real(dp), intent(inout) :: Bin
     real(dp), intent(inout) :: Bout
     real(dp), intent(inout) :: AssimToMobilize
@@ -745,16 +726,19 @@ subroutine InitializeTransferAssimilates_wrap(Bin, Bout, AssimToMobilize, &
     real(dp), intent(inout) :: FracAssim
     logical(1), intent(inout) :: StorageON
     logical(1), intent(inout) :: MobilizationON
+    logical(1), intent(inout) :: HarvestNow
 
-    logical :: StorageON_f, MobilizationON_f
+    logical :: StorageON_f, MobilizationON_f, HarvestNow_f
 
     StorageON_f = StorageON
     MobilizationON_f = MobilizationON
     call InitializeTransferAssimilates(Bin, Bout, AssimToMobilize, &
                                          AssimMobilized, FracAssim, &
-                                         StorageON_f, MobilizationON_f)
+                                         StorageON_f, MobilizationON_f, &
+                                         HarvestNow_f)
     StorageON = StorageON_f
     MobilizationON = MobilizationON_f
+    HarvestNow = HarvestNow_f
 end subroutine InitializeTransferAssimilates_wrap
 
 

--- a/src/interface_run.pas
+++ b/src/interface_run.pas
@@ -770,12 +770,6 @@ function GetNoMoreCrop() : boolean;
 procedure SetNoMoreCrop(constref NoMoreCrop_in : boolean);
         external 'aquacrop' name '__ac_interface_run_MOD_setnomorecrop_wrap';
 
-function GetCGCadjustmentAfterCutting() : boolean;
-        external 'aquacrop' name '__ac_interface_run_MOD_getcgcadjustmentaftercutting_wrap';
-
-procedure SetCGCadjustmentAfterCutting(constref CGCadjustmentAfterCutting_in : boolean);
-        external 'aquacrop' name '__ac_interface_run_MOD_setcgcadjustmentaftercutting_wrap';
-
 procedure fObs_open(constref filename : string; constref mode : string);
 
 procedure fObs_open_wrap(
@@ -849,12 +843,6 @@ procedure SetStressSFadjNEW(constref StressSFadjNEW : shortint);
 
 procedure GetNextHarvest()
     external 'aquacrop' name '__ac_run_MOD_getnextharvest';
-
-function GetCCxWitheredTpot() : double;
-    external 'aquacrop' name '__ac_run_MOD_getccxwitheredtpot';
-
-procedure SetCCxWitheredTpot(constref CCxWitheredTpot : double);
-    external 'aquacrop' name '__ac_run_MOD_setccxwitheredtpot';
 
 function GetCCxWitheredTpotNoS() : double;
     external 'aquacrop' name '__ac_run_MOD_getccxwitheredtpotnos';
@@ -1343,7 +1331,7 @@ procedure AdjustSWCRootZone(VAR PreIrri : double);
     external 'aquacrop' name '__ac_run_MOD_adjustswcrootzone';
 
 procedure InitializeTransferAssimilates(VAR Bin,Bout,AssimToMobilize,AssimMobilized,FracAssim : double;
-                                        VAR StorageOn,MobilizationOn : BOOLEAN);
+                                        VAR StorageOn,MobilizationOn,HarvestNow : BOOLEAN);
     external 'aquacrop' name '__ac_interface_run_MOD_initializetransferassimilates_wrap';
 
 procedure WriteIntermediatePeriod(TheProjectFile : string);

--- a/src/interface_simul.f90
+++ b/src/interface_simul.f90
@@ -25,7 +25,7 @@ subroutine DetermineBiomassAndYield_wrap(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, 
                                     BiomassTot, YieldPart, WPi, HItimesBEF, &
                                     ScorAT1, ScorAT2, HItimesAT1, HItimesAT2, &
                                     HItimesAT, alfa, alfaMax, SumKcTopStress, &
-                                    SumKci, CCxWitheredTpot, CCxWitheredTpotNoS, &
+                                    SumKci, &
                                     WeedRCi, CCw, Trw, StressSFadjNEW, &
                                     PreviousStressLevel, StoreAssimilates, &
                                     MobilizeAssimilates, AssimToMobilize, &
@@ -70,8 +70,6 @@ subroutine DetermineBiomassAndYield_wrap(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, 
     real(dp), intent(inout) :: alfaMax
     real(dp), intent(inout) :: SumKcTopStress
     real(dp), intent(inout) :: SumKci
-    real(dp), intent(inout) :: CCxWitheredTpot
-    real(dp), intent(inout) :: CCxWitheredTpotNoS
     real(dp), intent(inout) :: WeedRCi
     real(dp), intent(inout) :: CCw
     real(dp), intent(inout) :: Trw
@@ -101,7 +99,7 @@ subroutine DetermineBiomassAndYield_wrap(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, 
                                     BiomassTot, YieldPart, WPi, HItimesBEF, &
                                     ScorAT1, ScorAT2, HItimesAT1, HItimesAT2, &
                                     HItimesAT, alfa, alfaMax, SumKcTopStress, &
-                                    SumKci, CCxWitheredTpot, CCxWitheredTpotNoS, &
+                                    SumKci, &
                                     WeedRCi, CCw, Trw, StressSFadjNEW, &
                                     PreviousStressLevel, StoreAssimilates_f, &
                                     MobilizeAssimilates_f, AssimToMobilize, &
@@ -129,7 +127,7 @@ subroutine DetermineCCiGDD_wrap(CCxTotal, CCoTotal, &
                            StressLeaf, FracAssim, MobilizationON, &
                            StorageON, SumGDDAdjCC, VirtualTimeCC, &
                            StressSenescence, TimeSenescence, NoMoreCrop, &
-                           CDCTotal, CGCAdjustmentAfterCutting, GDDayFraction, &
+                           CDCTotal, GDDayFraction, &
                            GDDayi, GDDCDCTotal, GDDTadj)
     real(dp), intent(in) :: CCxTotal
     real(dp), intent(in) :: CCoTotal
@@ -143,28 +141,24 @@ subroutine DetermineCCiGDD_wrap(CCxTotal, CCoTotal, &
     real(dp), intent(inout) :: TimeSenescence
     logical(1), intent(inout) :: NoMoreCrop
     real(dp), intent(in) :: CDCTotal
-    logical(1), intent(inout) :: CGCAdjustmentAfterCutting
     real(dp), intent(in) :: GDDayFraction
     real(dp), intent(in) :: GDDayi
     real(dp), intent(in) :: GDDCDCTotal
     integer(int32), intent(in) :: GDDTadj
 
-    logical :: MobilizationON_f, StorageON_f, NoMoreCrop_f, &
-               CGCAdjustmentAfterCutting_f
+    logical :: MobilizationON_f, StorageON_f, NoMoreCrop_f
 
     MobilizationON_f = MobilizationON
     StorageON_f = StorageON
     NoMoreCrop_f = NoMoreCrop
-    CGCAdjustmentAfterCutting_f = CGCAdjustmentAfterCutting
 
     call DetermineCCiGDD(CCxTotal, CCoTotal, &
                            StressLeaf, FracAssim, MobilizationON_f, &
                            StorageON_f, SumGDDAdjCC, VirtualTimeCC, &
                            StressSenescence, TimeSenescence, NoMoreCrop_f, &
-                           CDCTotal, CGCAdjustmentAfterCutting_f, GDDayFraction, &
+                           CDCTotal, GDDayFraction, &
                            GDDayi, GDDCDCTotal, GDDTadj)
     NoMoreCrop = NoMoreCrop_f
-    CGCAdjustmentAfterCutting = CGCAdjustmentAfterCutting_f
 end subroutine DetermineCCiGDD_wrap
 
 
@@ -184,7 +178,7 @@ end subroutine ExtractWaterFromEvapLayer_wrap
 subroutine DetermineCCi_wrap(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
                         MobilizationON, StorageON, Tadj, VirtualTimeCC, &
                         StressSenescence, TimeSenescence, NoMoreCrop, &
-                        CDCTotal, CGCAdjustmentAfterCutting, DayFraction, &
+                        CDCTotal, DayFraction, &
                         GDDCDCTotal, TESTVAL)
     real(dp), intent(in) :: CCxTotal
     real(dp), intent(in) :: CCoTotal
@@ -198,26 +192,22 @@ subroutine DetermineCCi_wrap(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
     real(dp), intent(inout) :: TimeSenescence
     logical, intent(inout) :: NoMoreCrop
     real(dp), intent(in) :: CDCTotal
-    logical, intent(inout) :: CGCAdjustmentAfterCutting
     real(dp), intent(in) :: DayFraction
     real(dp), intent(in) :: GDDCDCTotal
     real(dp), intent(inout) :: TESTVAL
 
-    logical :: MobilizationON_f, StorageON_f, NoMoreCrop_f, &
-               CGCAdjustmentAfterCutting_f
+    logical :: MobilizationON_f, StorageON_f, NoMoreCrop_f
 
     MobilizationON_f = MobilizationON
     StorageON_f = StorageON
     NoMoreCrop_f = NoMoreCrop
-    CGCAdjustmentAfterCutting_f = CGCAdjustmentAfterCutting
 
     call DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
                         MobilizationON_f, StorageON_f, Tadj, VirtualTimeCC, &
                         StressSenescence, TimeSenescence, NoMoreCrop_f, &
-                        CDCTotal, CGCAdjustmentAfterCutting_f, DayFraction, &
+                        CDCTotal, DayFraction, &
                         GDDCDCTotal, TESTVAL)
     NoMoreCrop = NoMoreCrop_f
-    CGCAdjustmentAfterCutting = CGCAdjustmentAfterCutting_f
 end subroutine DetermineCCi_wrap
 
 
@@ -229,7 +219,7 @@ subroutine BUDGET_module_wrap(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC
                          DayFraction, GDDayFraction, FracAssim, &
                          StressSFadjNEW, StorageON, MobilizationON, &
                          StressLeaf, StressSenescence, TimeSenescence, &
-                         NoMoreCrop, CGCadjustmentAfterCutting, TESTVAL)
+                         NoMoreCrop, TESTVAL)
     integer(int32), intent(in) :: dayi
     integer(int32), intent(in) :: TargetTimeVal
     integer(int32), intent(in) :: TargetDepthVal
@@ -262,16 +252,14 @@ subroutine BUDGET_module_wrap(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC
     real(dp), intent(inout) :: StressSenescence
     real(dp), intent(inout) :: TimeSenescence
     logical(1), intent(inout) :: NoMoreCrop
-    logical(1), intent(inout) :: CGCadjustmentAfterCutting
     real(dp), intent(inout) :: TESTVAL
 
     logical :: StorageON_f, MobilizationON_f, &
-               NoMoreCrop_f, CGCadjustmentAfterCutting_f
+               NoMoreCrop_f
 
     StorageON_f = StorageON
     MobilizationON_f = MobilizationON
     NoMoreCrop_f = NoMoreCrop
-    CGCadjustmentAfterCutting_f = CGCadjustmentAfterCutting
 
     call BUDGET_module(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC, &
                          SumInterval, DayLastCut, NrDayGrow, Tadj, GDDTadj, &
@@ -281,10 +269,9 @@ subroutine BUDGET_module_wrap(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC
                          DayFraction, GDDayFraction, FracAssim, &
                          StressSFadjNEW, StorageON_f, MobilizationON_f, &
                          StressLeaf, StressSenescence, TimeSenescence, &
-                         NoMoreCrop_f, CGCadjustmentAfterCutting_f, TESTVAL)
+                         NoMoreCrop_f, TESTVAL)
 
     NoMoreCrop = NoMoreCrop_f
-    CGCadjustmentAfterCutting = CGCadjustmentAfterCutting_f
 end subroutine BUDGET_module_wrap
 
 end module ac_interface_simul

--- a/src/interface_simul.pas
+++ b/src/interface_simul.pas
@@ -66,8 +66,6 @@ procedure DetermineBiomassAndYield(
             VAR alfaMax : double;
             VAR SumKcTopStress : double;
             VAR SumKci : double;
-            VAR CCxWitheredTpot : double;
-            VAR CCxWitheredTpotNoS : double;
             VAR WeedRCi : double;
             VAR CCw : double;
             VAR Trws : double;
@@ -191,7 +189,6 @@ procedure DetermineCCiGDD(
             var TimeSenescence : double;
             var NoMoreCrop : boolean;
             constref CDCTotal : double;
-            var CGCAdjustmentAfterCutting : boolean;
             constref GDDayFraction, GDDayi, GDDCDCTotal : double;
             constref GDDTadj : integer);
     external 'aquacrop' name '__ac_interface_simul_MOD_determineccigdd_wrap';
@@ -250,7 +247,6 @@ procedure DetermineCCi(
                 var StressSenescence, TimeSenescence : double;
                 var NoMoreCrop : boolean;
                 constref CDCTotal : double;
-                var CGCAdjustmentAfterCutting : boolean;
                 constref DayFraction, GDDCDCTotal : double;
                 var TESTVAL : double);
     external 'aquacrop' name '__ac_interface_simul_MOD_determinecci_wrap';
@@ -276,7 +272,7 @@ procedure BUDGET_module(constref dayi : LongInt;
                         constref StorageON,MobilizationON : BOOLEAN;
                         VAR StressLeaf,StressSenescence : double;
                         VAR TimeSenescence : double;
-                        VAR NoMoreCrop,CGCadjustmentAfterCutting : BOOLEAN;
+                        VAR NoMoreCrop : BOOLEAN;
                         VAR TESTVAL : double);
     external 'aquacrop' name '__ac_interface_simul_MOD_budget_module_wrap';
 

--- a/src/run.f90
+++ b/src/run.f90
@@ -6388,8 +6388,7 @@ subroutine InitializeTransferAssimilates(Bin, Bout, AssimToMobilize, &
     logical, intent(inout) :: MobilizationON
     logical, intent(in) :: HarvestNow
 
-    integer(int32) :: c1, c2
-    real(dp) :: x, FracSto, tmob
+    real(dp) :: FracSto, tmob
 
     Bin = 0._dp
     Bout = 0._dp

--- a/src/run.f90
+++ b/src/run.f90
@@ -4700,11 +4700,11 @@ subroutine WriteTheResults(ANumber, Day1, Month1, Year1, DayN, MonthN, &
 
     ! Crop yield
     ! Harvest Index
-    if ((GetSumWaBal_Biomass() > 0._dp) &
-        .and. (GetSumWaBal_YieldPart() > 0._dp)) then
+    if ((GetSumWaBal_Biomass() > epsilon(0._dp)) &
+        .and. (GetSumWaBal_YieldPart() > epsilon(0._dp))) then
         HI = 100._dp*(GetSumWaBal_YieldPart())/(GetSumWaBal_Biomass())
     else
-        if (GetSumWaBal_Biomass() > 0._dp) then
+        if (GetSumWaBal_Biomass() > epsilon(0._dp)) then
             HI = 0._dp
         else
             HI = undef_double
@@ -6418,14 +6418,14 @@ subroutine InitializeTransferAssimilates(Bin, Bout, AssimToMobilize, &
                 if (AssimToMobilize > AssimMobilized) then
                     FracAssim = (exp(-5._dp*tmob) - 1._dp)/(exp(-5._dp) - 1._dp)
                     if (GetCCiActual() > (0.9_dp*(GetCCxTotal() &
-                        * (1._dp - GetSimulation_EffectStress_RedCCX()/100._dp)))) then
+                        * (1._dp - real(GetSimulation_EffectStress_RedCCX(), kind=dp)/100._dp)))) then
                         FracAssim = FracAssim * ((GetCCxTotal()*(1._dp &
-                        - GetSimulation_EffectStress_RedCCX()/100._dp)) &
+                        - real(GetSimulation_EffectStress_RedCCX(), kind=dp)/100._dp)) &
                         - GetCCiActual()) &
                         / (0.1*(GetCCxTotal()*(1._dp &
-                        - GetSimulation_EffectStress_RedCCX()/100._dp)))
+                        - real(GetSimulation_EffectStress_RedCCX(), kind=dp)/100._dp)))
                     end if
-                    if (FracAssim < 0._dp) then
+                    if (FracAssim < epsilon(0._dp)) then
                         FracAssim = 0._dp
                     end if
                 else
@@ -6440,9 +6440,9 @@ subroutine InitializeTransferAssimilates(Bin, Bout, AssimToMobilize, &
                 else
                     if ((GetCCiActual() > GetManagement_Cuttings_CCcut()/100._dp) &
                         .and. (GetCCiActual() < (GetCCxTotal()*(1._dp &
-                        - GetSimulation_EffectStress_RedCCX()/100._dp)))) then
+                        - real(GetSimulation_EffectStress_RedCCX(),kind=dp)/100._dp)))) then
                         FracSto = (GetCCiActual() - GetManagement_Cuttings_CCcut()/100._dp) &
-                            /((GetCCxTotal()*(1._dp - GetSimulation_EffectStress_RedCCX()/100._dp)) &
+                            /((GetCCxTotal()*(1._dp - real(GetSimulation_EffectStress_RedCCX(),kind=dp)/100._dp)) &
                             - GetManagement_Cuttings_CCcut()/100._dp)
                     else 
                         FracSto = 1._dp
@@ -6453,7 +6453,7 @@ subroutine InitializeTransferAssimilates(Bin, Bout, AssimToMobilize, &
                     * (1._dp-KsAny((((GetDayNri() - GetSimulation_DelayedDays() &
                     - GetCrop_Day1() + 1._dp) &
                     - (GetCrop_DaysToHarvest()-GetCrop_Assimilates_Period())) &
-                    /GetCrop_Assimilates_Period()),0._dp,1._dp,-5._dp))
+                    /real(GetCrop_Assimilates_Period(),kind=dp)),0._dp,1._dp,-5._dp))
             end if
             if (FracAssim < 0._dp) then
                 FracAssim = 0._dp

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -141,7 +141,6 @@ use ac_global, only: ActiveCells, &
                      GetIrriMode, &
                      GetManagement_BundHeight, &
                      GetManagement_CNcorrection, &
-                     GetManagement_Cuttings_CGCPlus, &
                      GetManagement_EffectMulchInS, &
                      GetManagement_EffectMulchOffS, &
                      GetManagement_FertilityStress, &
@@ -536,7 +535,7 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
                                     BiomassTot, YieldPart, WPi, HItimesBEF, &
                                     ScorAT1, ScorAT2, HItimesAT1, HItimesAT2, &
                                     HItimesAT, alfa, alfaMax, SumKcTopStress, &
-                                    SumKci, CCxWitheredTpot, CCxWitheredTpotNoS, &
+                                    SumKci, &
                                     WeedRCi, CCw, Trw, StressSFadjNEW, &
                                     PreviousStressLevel, StoreAssimilates, &
                                     MobilizeAssimilates, AssimToMobilize, &
@@ -581,8 +580,6 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
     real(dp), intent(inout) :: alfaMax
     real(dp), intent(inout) :: SumKcTopStress
     real(dp), intent(inout) :: SumKci
-    real(dp), intent(inout) :: CCxWitheredTpot
-    real(dp), intent(inout) :: CCxWitheredTpotNoS
     real(dp), intent(inout) :: WeedRCi
     real(dp), intent(inout) :: CCw
     real(dp), intent(inout) :: Trw
@@ -624,7 +621,7 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
             HIfinal_temp = GetSimulation_HIfinal()
             alfa = HarvestIndexDay((dayi-GetCrop_Day1()), GetCrop_DaysToFlowering(), &
                                    GetCrop_HI(), GetCrop_dHIdt(), GetCCiactual(), &
-                                   GetCrop_CCxAdjusted(), GetSimulParam_PercCCxHIfinal(), &
+                                   GetCrop_CCxAdjusted(), GetCrop_CCxWithered(), GetSimulParam_PercCCxHIfinal(), &
                                    GetCrop_Planting(), PercentLagPhase, HIfinal_temp)
             call SetSimulation_HIfinal(HIfinal_temp)
         end if
@@ -742,9 +739,6 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
             ! 1. Mobilize assimilates at start of season
             if (MobilizeAssimilates .eqv. .true.) then
                 ! mass to mobilize
-                if (FracAssim < 0.05_dp) then
-                    FracAssim = 0.05_dp
-                end if
                 Bin = FracAssim * WPi *(TrW/ETo)  ! ton/ha
                 if ((AssimMobilized + Bin) > AssimToMobilize) then
                     Bin = AssimToMobilize - AssimMobilized
@@ -805,7 +799,12 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
                     HItimesBEF = HImultiplier(RatioBM, RBM, GetCrop_HIincrease())
                 end if
                 if (GetCCiActual() <= 0.01_dp) then
-                    HItimesBEF = 0._dp ! no green canopy cover left at start of flowering;
+                    if ((GetCrop_CCxWithered() > 0._dp) &
+                        .and. (GetCCiActual() < GetCrop_CCxWithered())) then
+                        HItimesBEF = 0._dp ! no green canopy cover left at start of flowering;
+                    else
+                        HItimesBEF = 1._dp
+                    end if
                 end if
             end if
 
@@ -951,13 +950,10 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
         end if
     end if
 
-    ! 2bis. yield leafy vegetable crops
+    ! 2bis. yield leafy vegetable crops and forage crops
     if ((GetCrop_subkind() == subkind_Vegetative) .or. (GetCrop_subkind() == subkind_Forage)) then
         if (dayi >= (GetSimulation_DelayedDays() + GetCrop_Day1() + GetCrop_DaysToFlowering())) then
             ! calculation starts at crop day 1 (since days to flowering is 0)
-            if ((100._dp*CCw) < GetSimulParam_PercCCxHIfinal()) then
-                alfa = 0._dp
-            end if
             if (roundc(100._dp*ETo, mold=1)> 0._dp) then
                 ! with correction for transferred assimilates
                 if (GetSimulation_RCadj() > 0._dp) then
@@ -3235,7 +3231,7 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
                            StressLeaf, FracAssim, MobilizationON, &
                            StorageON, SumGDDAdjCC, VirtualTimeCC, &
                            StressSenescence, TimeSenescence, NoMoreCrop, &
-                           CDCTotal, CGCAdjustmentAfterCutting, GDDayFraction, &
+                           CDCTotal, GDDayFraction, &
                            GDDayi, GDDCDCTotal, GDDTadj)
     real(dp), intent(in) :: CCxTotal
     real(dp), intent(in) :: CCoTotal
@@ -3249,7 +3245,6 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
     real(dp), intent(inout) :: TimeSenescence
     logical, intent(inout) :: NoMoreCrop
     real(dp), intent(in) :: CDCTotal
-    logical, intent(inout) :: CGCAdjustmentAfterCutting
     real(dp), intent(in) :: GDDayFraction
     real(dp), intent(in) :: GDDayi
     real(dp), intent(in) :: GDDCDCTotal
@@ -3377,7 +3372,6 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
                         .and. (GetCCiPrev() <= (1.25_dp * CCoTotal)))) then
                 ! 2.a First day or very small CC as a result of senescence
                 ! (no adjustment for leaf stress)
-                CGCadjustmentAfterCutting = .false.
                 if (GetSimulation_ProtectedSeedling()) then
                     call SetCCiActual(CanopyCoverNoStressSF(&
                                 (VirtualTimeCC+GetSimulation_DelayedDays()+1), &
@@ -3465,14 +3459,10 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
                             GetSimulation_EffectStress_RedCCX()))
                     call SetCrop_CCoAdjusted(CCoTotal)
                     StressLeaf = -33._dp ! maximum canopy is reached;
-                    CGCadjustmentAfterCutting = .false.
-                        ! no increase of Canopy development after Cutting
                 end if
                 if (GetCCiActual() > CCxSFCD) then
                     call SetCCiActual(CCxSFCD)
                     StressLeaf = -33._dp ! maximum canopy is reached;
-                    CGCadjustmentAfterCutting = .false.
-                        ! no increase of Canopy development after Cutting
                 end if
             end if
             call SetCrop_CCxAdjusted(GetCCiActual())
@@ -3481,8 +3471,6 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
         ! (Mid-season (from tFinalCCx) or Late season stage)
         else
             StressLeaf = -33._dp ! maximum canopy is reached;
-            CGCadjustmentAfterCutting = .false.
-                ! no increase of Canopy development after Cutting
             if (GetCrop_CCxAdjusted() < 0._dp) then
                 call SetCrop_CCxAdjusted(GetCCiPrev())
             end if
@@ -3625,7 +3613,6 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
 
             if (TheSenescenceON) then
                 ! CanopySenescence
-                CGCadjustmentAfterCutting = .false.
                 call SetSimulation_EvapLimitON(.true.)
                 ! consider withered crop when not yet in late season
                 if (abs(TimeSenescence) < epsilon(0._dp)) then
@@ -3798,7 +3785,7 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
         real(dp), intent(inout) :: GDDCGCadjusted
 
         real(dp) :: Wrelative
-        real(dp) :: KsLeaf, MaxVal
+        real(dp) :: KsLeaf
         real(dp) :: SWCeffectiveRootZone, FCeffectiveRootZone, &
                     WPeffectiveRootZone
 
@@ -3842,47 +3829,6 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
                     GDDCGCadjusted = CGCGDDSF * KsLeaf
                     StressLeaf = 100._dp * (1._dp - KsLeaf)
                 end if
-            end if
-        end if
-
-        ! effect of transfer of assimilates on CGCGDD
-        if ((GDDCGCadjusted > 0.000001_dp) & ! CGCGDD can be adjusted
-            .and. (((GetCrop_subkind() == subkind_Forage) &
-                    .and. ((StorageON) .or. (MobilizationON))) &
-                                        ! transfer assimilates
-                    .or. (CGCadjustmentAfterCutting))) then
-                    ! increase of Canopy development after Cutting
-            ! decrease CGC during storage
-            if ((GetCrop_subkind() == subkind_Forage) .and. (StorageON)) then
-                GDDCGCadjusted = GDDCGCadjusted * (1._dp - FracAssim)
-            end if
-            ! increase CGC after cutting
-            if ((CGCadjustmentAfterCutting) &
-                    .and. (StorageON .eqv. .false.)) then
-                GDDCGCadjusted = GDDCGCadjusted &
-                                * (1._dp + GetManagement_Cuttings_CGCPlus() &
-                                                                  /100._dp)
-            end if
-            ! increase CGC during mobilization
-            if ((GetCrop_subkind() == subkind_Forage) &
-                    .and. (MobilizationON) &
-                    .and. (CGCadjustmentAfterCutting .eqv. .false.)) then
-                if ((CCxSFCD <= epsilon(0._dp)) &
-                    .or. (GetCCiPrev() >= 0.9_dp*CCxSFCD)) then
-                    MaxVal = 0._dp
-                else
-                    MaxVal = (1._dp - GetCCiPrev()/(0.9_dp*CCxSFCD))
-                    if (MaxVal > 1._dp) then
-                        MaxVal = 1._dp
-                    end if
-                    if (MaxVal < 0._dp) then
-                        MaxVal = 0._dp
-                    end if
-                end if
-                if (MaxVal > (FracAssim/2._dp)) then
-                    MaxVal = FracAssim/2._dp
-                end if
-                GDDCGCadjusted = GDDCGCadjusted * (1._dp + Maxval)
             end if
         end if
     end subroutine DetermineGDDCGCadjusted
@@ -4661,7 +4607,7 @@ end subroutine CalculateSoilEvaporationStage2
 subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
                         MobilizationON, StorageON, Tadj, VirtualTimeCC, &
                         StressSenescence, TimeSenescence, NoMoreCrop, &
-                        CDCTotal, CGCAdjustmentAfterCutting, DayFraction, &
+                        CDCTotal, DayFraction, &
                         GDDCDCTotal, TESTVAL)
     real(dp), intent(in) :: CCxTotal
     real(dp), intent(in) :: CCoTotal
@@ -4675,7 +4621,6 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
     real(dp), intent(inout) :: TimeSenescence
     logical, intent(inout) :: NoMoreCrop
     real(dp), intent(in) :: CDCTotal
-    logical, intent(inout) :: CGCAdjustmentAfterCutting
     real(dp), intent(in) :: DayFraction
     real(dp), intent(in) :: GDDCDCTotal
     real(dp), intent(inout) :: TESTVAL
@@ -4788,7 +4733,6 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
                     .and. (GetCCiPrev() <= (1.25_dp * CCoTotal)))) then
                 ! 2.a first day or very small CC as a result of senescence
                 ! (no adjustment for leaf stress)
-                CGCadjustmentAfterCutting = .false.
                 if (GetSimulation_ProtectedSeedling()) then
                     call SetCCiActual(CanopyCoverNoStressSF(&
                             (VirtualTimeCC+GetSimulation_DelayedDays()+1), &
@@ -4882,13 +4826,11 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
                             GetSimulation_EffectStress_RedCCX()))
                     call SetCrop_CCoAdjusted(CCoTotal)
                     StressLeaf = -33._dp ! maximum canopy is reached;
-                    CGCadjustmentAfterCutting = .false.
                     ! no increase anymore of CGC after cutting
                 end if
                 if (GetCCiActual() > CCxSFCD) then
                     call SetCCiActual(CCxSFCD)
                     StressLeaf = -33._dp ! maximum canopy is reached;
-                    CGCadjustmentAfterCutting = .false.
                     ! no increase anymore of CGC after cutting
                 end if
             end if
@@ -4897,7 +4839,6 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
             ! 3. Canopy can no longer develop (Mid-season (from tFinalCCx) or Late season stage)
         else
             StressLeaf = -33._dp ! maximum canopy is reached;
-            CGCadjustmentAfterCutting = .false. ! no increase anymore of CGC after cutting
             if (GetCrop_CCxAdjusted() < 0._dp) then
                 call SetCrop_CCxAdjusted(GetCCiPrev())
             end if
@@ -5035,7 +4976,6 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
 
             if (TheSenescenceON) then
                 ! CanopySenescence
-                CGCadjustmentAfterCutting = .false.
                 call SetSimulation_EvapLimitON(.true.)
                 ! consider withered crop when not yet in late season
                 if (abs(TimeSenescence) < epsilon(0._dp)) then
@@ -5227,7 +5167,7 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
     subroutine DetermineCGCadjusted(CGCadjusted)
         real(dp), intent(inout) :: CGCadjusted
 
-        real(dp) :: Wrelative, MaxVal
+        real(dp) :: Wrelative
         real(dp) :: KsLeaf
         real(dp) :: SWCeffectiveRootZone, FCeffectiveRootZone, &
                     WPeffectiveRootZone
@@ -5269,44 +5209,6 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
                                pLeafLLAct, GetCrop_KsShapeFactorLeaf())
                 CGCadjusted = CGCSF * KsLeaf
                 StressLeaf = 100._dp * (1._dp - KsLeaf)
-            end if
-        end if
-
-        ! effect of transfer of assimilates on CGC
-        if ((CGCadjusted > 0.000001_dp) & ! CGC can be adjusted
-            .and. (((GetCrop_subkind() == subkind_Forage) &
-            .and. ((StorageON) .or. (MobilizationON))) & ! transfer assimilates
-            .or. (CGCadjustmentAfterCutting))) then
-                ! increase of Canopy development after Cutting
-            ! decrease CGC during storage
-            if ((GetCrop_subkind() == subkind_Forage) .and. (StorageON)) then
-                CGCadjusted = CGCadjusted * (1._dp - FracAssim)
-            end if
-            ! increase CGC after cutting
-            if ((CGCadjustmentAfterCutting) .and. (StorageON)) then
-                CGCadjusted = CGCadjusted &
-                             * (1._dp + GetManagement_Cuttings_CGCPlus() &
-                                                               /100._dp)
-            end if
-            ! increase CGC during mobilization
-            if ((GetCrop_subkind() == subkind_Forage) .and. (MobilizationON) &
-                .and. (.not. CGCadjustmentAfterCutting)) then
-                if ((CCxSFCD < epsilon(0._dp)) &
-                    .or. (GetCCiPrev() >= 0.9_dp * CCxSFCD)) then
-                    MaxVal = 0._dp
-                else
-                    MaxVal = (1._dp - GetCCiPrev()/(0.9_dp * CCxSFCD))
-                    if (MaxVal > 1._dp) then
-                        MaxVal = 1._dp
-                    end if
-                    if (MaxVal < 0._dp) then
-                        MaxVal = 0._dp
-                    end if
-                end if
-                if (MaxVal > (FracAssim/2._dp)) then
-                    MaxVal = FracAssim/2._dp
-                end if
-                CGCadjusted = CGCadjusted * (1._dp + Maxval)
             end if
         end if
 
@@ -5516,7 +5418,7 @@ subroutine BUDGET_module(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC, &
                          DayFraction, GDDayFraction, FracAssim, &
                          StressSFadjNEW, StorageON, MobilizationON, &
                          StressLeaf, StressSenescence, TimeSenescence, &
-                         NoMoreCrop, CGCadjustmentAfterCutting, TESTVAL)
+                         NoMoreCrop, TESTVAL)
     integer(int32), intent(in) :: dayi
     integer(int32), intent(in) :: TargetTimeVal
     integer(int32), intent(in) :: TargetDepthVal
@@ -5549,7 +5451,6 @@ subroutine BUDGET_module(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC, &
     real(dp), intent(inout) :: StressSenescence
     real(dp), intent(inout) :: TimeSenescence
     logical, intent(inout) :: NoMoreCrop
-    logical, intent(inout) :: CGCadjustmentAfterCutting
     real(dp), intent(inout) :: TESTVAL
 
 
@@ -5663,13 +5564,13 @@ subroutine BUDGET_module(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC, &
                                  MobilizationON, StorageON, SumGDDAdjCC, &
                                  VirtualTimeCC, StressSenescence, &
                                  TimeSenescence, NoMoreCrop, CDCTotal, &
-                                 CGCAdjustmentAfterCutting, GDDayFraction, &
+                                 GDDayFraction, &
                                  GDDayi, GDDCDCTotal, GDDTadj)
             case default
             call DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
                               MobilizationON, StorageON, Tadj, VirtualTimeCC, &
                               StressSenescence, TimeSenescence, NoMoreCrop, &
-                              CDCTotal, CGCAdjustmentAfterCutting, &
+                              CDCTotal, &
                               DayFraction, GDDCDCTotal, TESTVAL)
         end select
     end if

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -865,7 +865,9 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
                       + GetCrop_DaysToFlowering()+ tmax1)) & ! and not yet end period
                 .and. (tmax1 > 0) & ! otherwise no effect
                 .and. (roundc(GetCrop_aCoeff(), mold=1) /= undef_int) & ! otherwise no effect
-                .and. (GetCCiactual() > 0.001_dp)) then ! and as long as green canopy cover remains (for correction to stresses)
+                ! possible precision issue in pascal code
+                ! added -epsilon(0._dp) for zero-diff with pascal version output
+                .and. (GetCCiactual() > (0.001_dp-epsilon(0._dp)))) then ! and as long as green canopy cover remains (for correction to stresses)
                 ! determine KsLeaf
                 call AdjustpLeafToETo(ETo, pLeafULAct, pLeafLLAct)
                 Ksleaf = KsAny(Wrel, pLeafULAct, pLeafLLAct, GetCrop_KsShapeFactorLeaf())
@@ -889,7 +891,9 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
                       + GetCrop_DaysToFlowering() + tmax2)) & ! and not yet end period
                 .and. (tmax2 > 0) & ! otherwise no effect
                 .and. (roundc(GetCrop_bCoeff(), mold=1) /= undef_int) & ! otherwise no effect
-                .and. (GetCCiactual() > 0.001_dp)) then ! and as long as green canopy cover remains (for correction to stresses)
+                ! possible precision issue in pascal code
+                ! added -epsilon(0._dp) for zero-diff with pascal version output
+                .and. (GetCCiactual() > (0.001_dp-epsilon(0._dp)))) then ! and as long as green canopy cover remains (for correction to stresses)
                 ! determine KsStomatal
                 call AdjustpStomatalToETo(ETo, pStomatULAct)
                 pLL = 1._dp

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -4219,7 +4219,7 @@ subroutine PrepareStage2()
     AtTheta = whichtheta_AtAct
     Wact = WCEvapLayer(GetSimulation_EvapZ(), AtTheta)
 
-    if ((Wact - (WFC-GetSoil_REW())) < 0._dp) then
+    if ((Wact - (WFC-GetSoil_REW())) <= epsilon(0._dp)) then
         EvapStartStg2 = 0_int8
     else
         EvapStartStg2 = roundc(100._dp * (Wact - (WFC-GetSoil_REW())) &

--- a/src/startunit.F90
+++ b/src/startunit.F90
@@ -542,7 +542,7 @@ subroutine InitializeProject(iproject, TheProjectFile, TheProjectType)
     integer(int32) :: TotalSimRuns
     integer(int32) :: SimNr
     integer(int32) :: WrongSimNr
-    character(len=:), allocatable :: FullFileNameProgramParametersLocal
+    character(len=1025) :: FullFileNameProgramParametersLocal
     logical :: MultipleRunWithKeepSWC_temp
     real(dp) :: MultipleRunConstZrx_temp
     type(rep_FileOK) :: FileOK
@@ -580,7 +580,7 @@ subroutine InitializeProject(iproject, TheProjectFile, TheProjectType)
             ! 4. load project parameters
             if (CanSelect) then
                 call SetProjectDescription('undefined')
-                FullFileNameProgramParametersLocal = GetFullFileNameProgramParameters()
+                FullFileNameProgramParametersLocal = ''
                 call ComposeFileForProgramParameters(GetProjectFile(), &
                                          FullFileNameProgramParametersLocal)
                 call SetFullFileNameProgramParameters(FullFileNameProgramParametersLocal)
@@ -616,7 +616,7 @@ subroutine InitializeProject(iproject, TheProjectFile, TheProjectType)
             ! 4. load project parameters
             if (CanSelect) then
                 call SetMultipleProjectDescription('undefined')
-                FullFileNameProgramParametersLocal = GetFullFileNameProgramParameters()
+                FullFileNameProgramParametersLocal = ''
                 call ComposeFileForProgramParameters(GetMultipleProjectFile(), &
                                             FullFileNameProgramParametersLocal)
                 call SetFullFileNameProgramParameters(FullFileNameProgramParametersLocal)
@@ -739,22 +739,25 @@ subroutine ComposeFileForProgramParameters(TheFileNameProgram, &
 
     integer(int32) :: TheLength
     character(len=len(TheFileNameProgram)) :: tempstring
+    character(len=1024) :: tempstring2
     character(len=3) :: TheExtension
 
-    FullFileNameProgramParameters = ''
     TheLength = len(TheFileNameProgram)
     tempstring = TheFileNameProgram
-    TheExtension = tempstring(TheLength-2:3) ! PRO or PRM
+    TheExtension = tempstring((TheLength-2):TheLength) ! PRO or PRM
     ! file name program parameters
-    FullFileNameProgramParameters = tempstring(1:TheLength-3)
+    tempstring = TheFileNameProgram
+    FullFileNameProgramParameters = trim(tempstring(1:(TheLength-3)))
     ! path file progrm parameters
-    FullFileNameProgramParameters = trim(GetPathNameParam()) // &
-                                FullFileNameProgramParameters
+    write(tempstring2,'(2a)') GetPathNameParam(),trim(FullFileNameProgramParameters)
+    FullFileNameProgramParameters = tempstring2
     ! extension file program parameters
     if (TheExtension == 'PRO') then
-        FullFileNameProgramParameters = FullFileNameProgramParameters // 'PP1'
+        write(tempstring2,'(2a)') trim(FullFileNameProgramParameters),'PP1'
+        FullFileNameProgramParameters = trim(tempstring2)
     else
-        FullFileNameProgramParameters = FullFileNameProgramParameters // 'PPn'
+        write(tempstring2,'(2a)') trim(FullFileNameProgramParameters),'PPn'
+        FullFileNameProgramParameters = trim(tempstring2)
     end if
 end subroutine ComposeFileForProgramParameters
 

--- a/src/startunit.F90
+++ b/src/startunit.F90
@@ -588,6 +588,8 @@ subroutine InitializeProject(iproject, TheProjectFile, TheProjectType)
                                 GetFullFileNameProgramParameters(), &
                                 ProgramParametersAvailable)
                 call ComposeOutputFileName(GetProjectFile())
+            else
+                WrongSimNr = 1_int32
             end if
 
         case(typeproject_TypePRM)
@@ -647,40 +649,67 @@ subroutine InitializeProject(iproject, TheProjectFile, TheProjectType)
                 call fProjects_write(trim(tempstring))
             end if
         else
-            !write(tempstring, '(4a)') trim(NrString), '. - ', &
-            !                         trim(TheProjectFile), ' : Project NOT loaded', &
-            !                ' - Missing Environment and/or Simulation file(s) in &
-            !            Run number ', '0'
-            !            !Run number ', int2str(WrongSimNr)
-            write(tempstring, '(4a)') '          - Cannot find file(s) for: '    
-            if (.not. FileOK%Climate_Filename) &
-                write(tempstring, '(4a)') 'Climate (CLI), '
-            if (.not. FileOK%Temperature_Filename) & 
-                write(tempstring, '(4a)') 'Temperature (Tnx of TMP), '
-            if (.not. FileOK%ETo_Filename) &
-                write(tempstring, '(4a)') 'Reference ET (ETo), '
-            if (.not. FileOK%Rain_Filename) &
-                write(tempstring, '(4a)') 'Rainfall (PLU), '
-            if (.not. FileOK%CO2_Filename) &
-                write(tempstring, '(4a)') 'CO2 (CO2), '
-            if (.not. FileOK%Calendar_Filename) &
-                write(tempstring, '(4a)') 'Calendar (CAL), '
-            if (.not. FileOK%Crop_Filename) &
-                write(tempstring, '(4a)') 'Crop (CRO), '
-            if (.not. FileOK%Irrigation_Filename) &
-                write(tempstring, '(4a)') 'Irrigation (Irr), '
-            if (.not. FileOK%Management_Filename) &
-                write(tempstring, '(4a)') 'Field Management (MAN), '
-            if (.not. FileOK%GroundWater_Filename) &
-                write(tempstring, '(4a)') 'Soil profile (SOL), '
-            if (.not. FileOK%Soil_Filename) &
-                write(tempstring, '(4a)') 'Groundwater (GWT), '
-            if (.not. FileOK%SWCIni_Filename) &
-                write(tempstring, '(4a)') 'Initial conditions (SW0), '
-            if (.not. FileOK%OffSeason_Filename) &
-                write(tempstring, '(4a)') 'Off-season (OFF), '
-            if (.not. FileOK%Observations_Filename) &
-                write(tempstring, '(4a)') 'Field data (OBS), '
+            write(tempstring, '(7a)') trim(NrString), '. - ', &
+                                     trim(TheProjectFile), ' : Project NOT loaded', &
+                            ' - Missing Environment and/or Simulation file(s) in Run number ', &
+                            int2str(WrongSimNr), ': '
+            call fProjects_write(trim(tempstring))
+            if (.not. FileOK%Climate_Filename) then
+                write(tempstring, '(4a)') '               Climate (CLI), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%Temperature_Filename) then
+                write(tempstring, '(4a)') '               Temperature (Tnx of TMP), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%ETo_Filename) then
+                write(tempstring, '(4a)') '               Reference ET (ETo), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%Rain_Filename) then
+                write(tempstring, '(4a)') '               Rainfall (PLU), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%CO2_Filename) then
+                write(tempstring, '(4a)') '               CO2 (CO2), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%Calendar_Filename) then
+                write(tempstring, '(4a)') '               Calendar (CAL), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%Crop_Filename) then
+                write(tempstring, '(4a)') '               Crop (CRO), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%Irrigation_Filename) then
+                write(tempstring, '(4a)') '               Irrigation (Irr), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%Management_Filename) then
+                write(tempstring, '(4a)') '               Field Management (MAN), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%GroundWater_Filename) then
+                write(tempstring, '(4a)') '               Soil profile (SOL), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%Soil_Filename) then
+                write(tempstring, '(4a)') '               Groundwater (GWT), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%SWCIni_Filename) then
+                write(tempstring, '(4a)') '               Initial conditions (SW0), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%OffSeason_Filename) then
+                write(tempstring, '(4a)') '               Off-season (OFF), '
+                call fProjects_write(trim(tempstring))
+            end if
+            if (.not. FileOK%Observations_Filename) then
+                write(tempstring, '(4a)') '               Field data (OBS), '
+                call fProjects_write(trim(tempstring))
+            end if
             write(tempstring, '(4a)') '          - Check file Name(s), Path(s) &
                                or Structure of project file.'
             call fProjects_write(trim(tempstring))

--- a/src/startunit.F90
+++ b/src/startunit.F90
@@ -713,6 +713,8 @@ subroutine InitializeProject(iproject, TheProjectFile, TheProjectType)
             write(tempstring, '(4a)') '          - Check file Name(s), Path(s) &
                                or Structure of project file.'
             call fProjects_write(trim(tempstring))
+            write(*,*) 'Missing Environment and/or Simulation file(s):'
+            write(*,*) 'Check OUTP/ListProjectsLoaded.OUT for information.'
         end if
     else
         ! not a project file or missing in the LIST  dirtectory

--- a/src/tempprocessing.f90
+++ b/src/tempprocessing.f90
@@ -261,7 +261,8 @@ use ac_global , only: undef_int, &
                       setcrop_ccini,&
                       setgroundwaterfile,&
                       setsimulation_surfacestorageini,&
-                      translateinipointstoswprofile
+                      translateinipointstoswprofile,&
+                      KsAny
 use ac_kinds,  only: dp, &
                      int8, &
                      int16, &
@@ -1620,138 +1621,6 @@ integer(int32) function RoundedOffGDD(PeriodGDD, PeriodDay,&
     end if
 end function RoundedOffGDD
 
-
-subroutine HIadjColdHeat(TempFlower, TempLengthFlowering, &
-                         TempHI, TempTmin, TempTmax, &
-                         TempTcold, TempTheat, TempfExcess, &
-                         HIadjusted, ColdStress, HeatStress)
-    integer(int32), intent(in) :: TempFlower
-    integer(int32), intent(in) :: TempLengthFlowering
-    integer(int32), intent(in) :: TempHI
-    real(dp), intent(in) :: TempTmin
-    real(dp), intent(in) :: TempTmax
-    integer(int8), intent(in) :: TempTcold
-    integer(int8), intent(in) :: TempTheat
-    integer(int16), intent(in) :: TempfExcess
-    real(dp), intent(inout) :: HIadjusted
-    logical, intent(inout) :: ColdStress
-    logical, intent(inout) :: HeatStress
-
-    integer(int32), parameter :: TempRange = 5
-    integer(int32) :: fhandle
-    integer(int32) :: Dayi,rc
-    real(dp) :: Tndayi, Txdayi, KsPol, KsPolCS, KsPolHS, fFlor
-
-    ! 1. Open Temperature file
-    if (GetTemperatureFile() /= '(None)') then
-        open(newunit=fhandle, &
-             file=trim(GetPathNameSimul())//trim('TCrop.SIM'),&
-             status='old', action='read', iostat=rc)
-        do Dayi = 1, (TempFlower-1)
-            read(fhandle, *, iostat=rc)
-        end do
-    end if
-
-    ! 2. Initialize
-    HIadjusted = 0._dp
-    ColdStress = .false.
-    HeatStress = .false.
-
-    ! 3. Cold or Heat stress affecting pollination
-    do Dayi = 1, TempLengthFlowering
-        ! 3.1 Read air temperature
-        if (GetTemperatureFile() /= '(None)') then
-            read(fhandle, *, iostat=rc) Tndayi, Txdayi
-        else
-            Tndayi = TempTmin
-            Txdayi = TempTmax
-        end if
-        ! 3.2 Fraction of flowers which are flowering on day  (fFlor)
-        fFlor = FractionFlowering(dayi)
-        ! 3.3 Ks(pollination) cold stress
-        KsPolCS = KsTemperature(real(TempTcold-TempRange, kind=dp), &
-                      real(TempTcold, kind=dp), Tndayi)
-        if (roundc(10000._dp*KsPolCS, mold=1_int32) < 10000) then
-            ColdStress = .true.
-        end if
-        ! 3.4 Ks(pollination) heat stress
-        KsPolHS = KsTemperature(real(TempTheat+TempRange, kind=dp), &
-                     real(TempTheat, kind=dp), Txdayi)
-        if (roundc(10000._dp*KsPolHS, mold=1_int32) < 10000) then
-            HeatStress = .true.
-        end if
-        ! 3.5 Adjust HI
-        KsPol = 1
-        if (KsPol > KsPolCS) then
-            KsPol = KsPolCS
-        end if
-        if (KsPol > KsPolHS) then
-            KsPol = KsPolHS
-        end if
-        HIadjusted = HIadjusted + (KsPol * (1._dp + TempfExcess/100._dp) &
-                                         * fFlor * TempHI)
-        if (HIadjusted > TempHI) then
-            HIadjusted = TempHI
-        end if
-    end do
-
-    ! 3. Close Temperature file
-    if (GetTemperatureFile() /= '(None)') then
-        close(fhandle)
-    end if
-
-
-    contains
-
-
-    real(dp) function FractionFlowering(Dayi)
-      integer(int32), intent(in) :: Dayi
-
-      real(dp) :: f1, f2, F
-      integer(int32) :: DiFlor
-
-      if (TempLengthFlowering <=1) then
-          F = 1._dp
-      else
-          DiFlor = Dayi
-          f2 = FractionPeriod(DiFlor,TempLengthFlowering)
-          DiFlor = Dayi-1
-          f1 = FractionPeriod(DiFlor,TempLengthFlowering)
-          f1 = FractionPeriod(DiFlor,TempLengthFlowering)
-          if (abs(f1-f2) < 0.0000001) then
-              F = 0._dp
-          else
-              F = ((f1+f2)/2._dp)* 100._dp/TempLengthFlowering
-          end if
-      end if
-      FractionFlowering = F
-    end function FractionFlowering
-
-
-    real(dp) function FractionPeriod(DiFlor,TempLengthFlowering)
-        integer(int32), intent(in) :: DiFlor,TempLengthFlowering
-
-        real(dp) :: fi, TimePerc
-
-        if (DiFlor <= 0) then
-            fi = 0._dp
-        else
-            TimePerc = 100._dp * (DiFlor/TempLengthFlowering)
-            if (TimePerc > 100) then
-                fi = 1._dp
-            else
-                fi = 0.00558 * exp(0.63*log(TimePerc)) - &
-                     0.000969 * TimePerc - 0.00383
-                if (fi < 0) then
-                    fi = 0._dp
-                end if
-            end if
-        end if
-        FractionPeriod = fi
-    end function FractionPeriod
-end subroutine HIadjColdHeat
-
-
 integer(int32) function ResetCropDay1(CropDay1IN, SwitchToYear1)
     integer(int32), intent(in) :: CropDay1IN
     logical, intent(in) :: SwitchToYear1
@@ -2703,8 +2572,9 @@ subroutine BTransferPeriod(TheDaysToCCini, TheGDDaysToCCini,&
                     SumBtot = SumBtot +  WPbio * (TpotForB/EToStandard)
                     SumBstored = SumBstored + WPbio*(TpotForB/EToStandard)*&
                             (0.01_dp*TempAssimStored)*&
-                            ((Dayi-StartStorage+1._dp)/&
-                             real(TempAssimPeriod, kind=dp))
+                            (1-KsAny(((Dayi-StartStorage+1._dp)/&
+                               real(TempAssimPeriod, kind=dp)),&
+                               0._dp,1._dp,-5._dp));
                end if
            end if
 

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -64,7 +64,7 @@ function GetReleaseDate() result(str)
     !! Returns a string containing the month and year of the release.
     character(len=:), allocatable :: str
 
-    str = 'August 2022'
+    str = 'August 2023'
 end function GetReleaseDate
 
 
@@ -72,7 +72,7 @@ function GetVersionString() result(str)
     !! Returns a string containing the version number (major+minor).
     character(len=:), allocatable :: str
 
-    str = '7.0'
+    str = '7.1'
 end function GetVersionString
 
 


### PR DESCRIPTION
This PR includes all Fortran code changes related to the V71 release. 
Test results (DEBUG=0 and DEBUG=1):
CassavaTest.PRO
--> zero-diff with pascal executable
Alf2Isp50.PRM
--> rounding differences (last digit) with pascal executable for WC12 (and related variables) in all time steps which I think was observed in an earlier corner case test (@lbusschaert?)
Ottawa.PRM: rounding differences (last digit) for some time steps 

ToDo: 
Updating of V71 release notes: Include bug fix related to the reading of program parameters
