### PR TITLE
BUG: default crop parameter update in standalone 

### DIFF
--- a/src/defaultcropsoil.f90
+++ b/src/defaultcropsoil.f90
@@ -245,7 +245,7 @@ subroutine ResetDefaultCrop(use_default_crop_file)
     call SetCrop_WP(17.0_dp) ! (normalized) Water productivity (gram/m2)
     call SetCrop_WPy(100) ! (normalized) Water productivity during yield formation
                           ! (Percent of WP)
-    call SetCrop_AdaptedToCO2(50_int8) ! Percentage adapted to elevated atmospheric
+    call SetCrop_AdaptedToCO2(100_int8) ! Percentage adapted to elevated atmospheric
                                        ! CO2 concentration
     call SetCrop_HI(50) ! HI harvest index (percentage)
     call SetCrop_DryMatter(25_int8) ! dry matter content (%) of fresh yield


### PR DESCRIPTION
The default crop parameter "AdaptedToCO2" (Percentage adapted to elevated atmospheric CO2 concentration) has been recently changed from 50 to 100 in the GUI. The standalone was still running with a default value of 50. This PR makes it consistent.  