### PR TITLE
BUG: Incorrect determination of NrObs

### DIFF
--- a/src/global.f90
+++ b/src/global.f90
@@ -5968,6 +5968,7 @@ subroutine LoadClim(FullName, ClimateDescription, ClimateRecord)
     read(fhandle, *, iostat=rc)
     read(fhandle, *, iostat=rc)
     ClimateRecord%NrObs = 0
+    read(fhandle, *, iostat=rc)
     do while (rc /= iostat_end)
         ClimateRecord%NrObs = ClimateRecord%NrObs + 1
         read(fhandle, *, iostat=rc)


### PR DESCRIPTION
This PR fixes another bug related to #334 which popped up when working with climate data of 12 months length only (simulation period day 1 through 365). The bug is related to a misinterpretation of the differences in the End-of-file information between Pascal and Fortran.
After reading the last line of a file, Eof function in PASCAL will return **true**, even though data has been read successfully.
The rc output of Fortran reports the successful reading without returning the information it was the last line.
I added an additional readln before the while statement which allows to determine the correct number of observations in the file.
I found zero difference for the V71 testcases after fixing the bug. But it will solve the new issue raised in #334.
ToDo: There might be a similar bug in the reading of groundwater data. Requires a setup of another experiment.  