### PR TITLE
BUG: resolving diffs bwteen DEBUG=0 and DEBUG=0 (Alfalfa)

### DIFF
--- a/src/run.f90
+++ b/src/run.f90
@@ -6744,11 +6744,11 @@ end subroutine RecordHarvest
 !--------end duplicate--------!
 
 
-subroutine AdvanceOneTimeStep(WPi)
+subroutine AdvanceOneTimeStep(WPi, HarvestNow)
     real(dp), intent(inout) :: WPi
+    logical, intent(inout) :: HarvestNow
 
     real(dp) :: PotValSF, KsTr, TESTVALY, PreIrri, StressStomata, FracAssim
-    logical :: HarvestNow
     integer(int32) :: VirtualTimeCC, DayInSeason
     real(dp) :: SumGDDadjCC, RatDGDD, &
                 Biomass_temp, BiomassPot_temp, BiomassUnlim_temp, &
@@ -7761,12 +7761,14 @@ subroutine FileManagement()
 
     integer(int32) :: RepeatToDay
     real(dp) :: WPi
+    logical :: HarvestNow
 
     WPi = 0._dp
+    HarvestNow = .false.
     RepeatToDay = GetSimulation_ToDayNr()
 
     loop: do
-        call AdvanceOneTimeStep(WPi)
+        call AdvanceOneTimeStep(WPi, HarvestNow)
         call ReadClimateNextDay()
         call SetGDDVariablesNextDay()
         if ((GetDayNri()-1) == RepeatToDay) exit loop


### PR DESCRIPTION
**Problem**: differences in output (Biomass and related variables, not the water balance) between a compilation with optimization (DEBUG=0) and with a debug flag (DEBUG=0).
**Cause**: HarvestNow should be kept in memory when calling AdvanceOneTimeStep in FileManagement. HarvestNow was erroneous and caused problems in InitializeTransferAssimilates (L6437 of run.f90), ultimately causing differences in the biomass. Why this was not the case for DEBUG=0 is not entirely clear (probably related to the optimization, that somehow the HarvestNow was kept in the memory).
**Solution**: initialize HarvestNow to .false. and define it as an inout argument of AdvanceOneTimeStep.
**Testing**: zero diff for Ottawa, Cassava and AlfIsp testcases between DEBUG=0 and DEBUG=1. Still minor rounding differences when compared to output of Pascal Standalone (as previously).