### PR TITLE
BUG: ensuring zero diff with GUI for Tunis case

### DIFF
--- a/src/global.f90
+++ b/src/global.f90
@@ -5605,7 +5605,7 @@ real(dp) function HarvestIndexDay(DAP, DaysToFlower, HImax, dHIdt, CCi, &
         ! adjust HIfinal if required for inadequate photosynthesis (unsufficient green canopy)
         tMax = roundc(HImax/dHIdt_local, mold=1)
         if ((HIfinal == HImax) .and. (t <= tmax) &
-                              .and. (CCi <= (PercCCxHIfinal/100._dp)) &
+                              .and. ((CCi+epsilon(0._dp)) <= (PercCCxHIfinal/100._dp)) &
                               .and. (TheCCxWithered > epsilon(0._dp)) &
                               .and. (CCi < TheCCxWithered) &
                               .and. (GetCrop_subkind() /= subkind_Vegetative) &


### PR DESCRIPTION
This PR treats a value precision difference between windows and linux systems and ensures zero difference between standalone codes and the GUI. The water stress impact on yield was shifted by one day since a threshold was reached a day later due to a precision difference (CC and the threshold both were 5, but one with double precision and the other with integer).  