### PR TITLE
ENH: V72 release changes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -75,6 +75,7 @@ all: bin lib
 OBJ = climprocessing.o \
     defaultcropsoil.o \
     global.o  \
+    preparefertilitysalinity.o  \
     inforesults.o \
     initialsettings.o \
     kinds.o \
@@ -144,17 +145,6 @@ rootunit.o: rootunit.f90 \
     utils.o
 	$(FC) $(FCFLAGS) -c $< -o $@
 
-run.o: run.f90 \
-    global.o \
-    inforesults.o \
-    kinds.o \
-    rootunit.o \
-    simul.o \
-    tempprocessing.o \
-    climprocessing.o \
-    utils.o
-	$(FC) $(FCFLAGS) -c $< -o $@
-
 simul.o: simul.f90 \
     global.o \
     tempprocessing.o \
@@ -169,10 +159,30 @@ startunit.o: startunit.F90 \
     utils.o
 	$(FC) $(FCFLAGS) -c $< -o $@
 
+preparefertilitysalinity.o: preparefertilitysalinity.f90 \
+    global.o \
+    kinds.o \
+    tempprocessing.o \
+    project_input.o \
+    utils.o
+	$(FC) $(FCFLAGS) -c $< -o $@
+
 tempprocessing.o: tempprocessing.f90 \
     global.o \
     kinds.o \
     project_input.o \
+    utils.o
+	$(FC) $(FCFLAGS) -c $< -o $@
+
+run.o: run.f90 \
+    global.o \
+    inforesults.o \
+    kinds.o \
+    rootunit.o \
+    simul.o \
+    tempprocessing.o \
+    climprocessing.o \
+    preparefertilitysalinity.o \
     utils.o
 	$(FC) $(FCFLAGS) -c $< -o $@
 

--- a/src/global.f90
+++ b/src/global.f90
@@ -1060,10 +1060,10 @@ real(dp) :: TmaxCropReference ! degC
 real(dp) :: TminCropReference ! degC
 real(dp) :: TmaxTnxReference365Days ! degC
 real(dp) :: TminTnxReference365Days ! degC
-real(dp), dimension(1:366) :: TmaxRun, TminRun
-real(dp), dimension(1:12) ::  TmaxTnxReference12MonthsRun, TminTnxReference12MonthsRun
-real(dp), dimension(1:365) :: TmaxCropReferenceRun, TminCropReferenceRun
-real(dp), dimension(1:365) :: TmaxTnxReference365DaysRun, TminTnxReference365DaysRun
+real(sp), dimension(1:366) :: TmaxRun, TminRun
+real(sp), dimension(1:12) ::  TmaxTnxReference12MonthsRun, TminTnxReference12MonthsRun
+real(sp), dimension(1:365) :: TmaxCropReferenceRun, TminCropReferenceRun
+real(sp), dimension(1:365) :: TmaxTnxReference365DaysRun, TminTnxReference365DaysRun
 
 logical :: EvapoEntireSoilSurface ! True of soil wetted by RAIN (false = IRRIGATION and fw < 1)
 logical :: PreDay, OutDaily, Out8Irri
@@ -2883,7 +2883,6 @@ subroutine LoadIrriScheduleInfo(FullName)
     real(dp) :: VersionNr
     integer(int8) :: simul_irri_in
     integer(int32) :: simul_percraw
-    character(len=1025) :: StringREAD
 
     open(newunit=fhandle, file=trim(FullName), status='old', action='read')
     read(fhandle, '(a)', iostat=rc) IrriDescription
@@ -16230,7 +16229,7 @@ end subroutine SetTactWeedInfested
 
 function GetTminTnxReference365DaysRun() result(TminTnxReference365DaysRun_out)
     !! Getter for the "TminTnxReference365DaysRun" global variable.
-    real(dp), dimension(1:365) :: TminTnxReference365DaysRun_out
+    real(sp), dimension(1:365) :: TminTnxReference365DaysRun_out
 
     TminTnxReference365DaysRun_out = TminTnxReference365DaysRun
 end function GetTminTnxReference365DaysRun
@@ -16239,15 +16238,16 @@ end function GetTminTnxReference365DaysRun
 function GetTminTnxReference365DaysRun_i(i) result(TminTnxReference365DaysRun_i)
     !! Getter for individual elements of the "GetTminTnxReference365DaysRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp) :: TminTnxReference365DaysRun_i
+    real(sp) :: TminTnxReference365DaysRun_i
 
     TminTnxReference365DaysRun_i = TminTnxReference365DaysRun(i)
+    !TminTnxReference365DaysRun_i = real(roundc(10000*real(TminTnxReference365DaysRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTminTnxReference365DaysRun_i
 
 
 subroutine SetTminTnxReference365DaysRun(TminTnxReference365DaysRun_in)
     !! Setter for the "TminTnxReference365DaysRun" global variable.
-    real(dp), dimension(1:365), intent(in) :: TminTnxReference365DaysRun_in
+    real(sp), dimension(1:365), intent(in) :: TminTnxReference365DaysRun_in
 
     TminTnxReference365DaysRun = TminTnxReference365DaysRun_in
 end subroutine SetTminTnxReference365DaysRun
@@ -16256,7 +16256,7 @@ end subroutine SetTminTnxReference365DaysRun
 subroutine SetTminTnxReference365DaysRun_i(i, TminTnxReference365DaysRun_i)
     !! Setter for individual element for the "TminTnxReference365DaysRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp), intent(in) :: TminTnxReference365DaysRun_i
+    real(sp), intent(in) :: TminTnxReference365DaysRun_i
 
     TminTnxReference365DaysRun(i) = TminTnxReference365DaysRun_i
 end subroutine SetTminTnxReference365DaysRun_i
@@ -16265,7 +16265,7 @@ end subroutine SetTminTnxReference365DaysRun_i
 
 function GetTmaxTnxReference365DaysRun() result(TmaxTnxReference365DaysRun_out)
     !! Getter for the "TmaxTnxReference365DaysRun" global variable.
-    real(dp), dimension(1:365) :: TmaxTnxReference365DaysRun_out
+    real(sp), dimension(1:365) :: TmaxTnxReference365DaysRun_out
 
     TmaxTnxReference365DaysRun_out = TmaxTnxReference365DaysRun
 end function GetTmaxTnxReference365DaysRun
@@ -16274,15 +16274,16 @@ end function GetTmaxTnxReference365DaysRun
 function GetTmaxTnxReference365DaysRun_i(i) result(TmaxTnxReference365DaysRun_i)
     !! Getter for individual elements of the "GetTmaxTnxReference365DaysRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp) :: TmaxTnxReference365DaysRun_i
+    real(sp) :: TmaxTnxReference365DaysRun_i
 
     TmaxTnxReference365DaysRun_i = TmaxTnxReference365DaysRun(i)
+    !TmaxTnxReference365DaysRun_i = real(roundc(10000*real(TmaxTnxReference365DaysRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTmaxTnxReference365DaysRun_i
 
 
 subroutine SetTmaxTnxReference365DaysRun(TmaxTnxReference365DaysRun_in)
     !! Setter for the "TmaxTnxReference365DaysRun" global variable.
-    real(dp), dimension(1:365), intent(in) :: TmaxTnxReference365DaysRun_in
+    real(sp), dimension(1:365), intent(in) :: TmaxTnxReference365DaysRun_in
 
     TmaxTnxReference365DaysRun = TmaxTnxReference365DaysRun_in
 end subroutine SetTmaxTnxReference365DaysRun
@@ -16291,13 +16292,13 @@ end subroutine SetTmaxTnxReference365DaysRun
 subroutine SetTmaxTnxReference365DaysRun_i(i, TmaxTnxReference365DaysRun_i)
     !! Setter for individual element for the "TmaxTnxReference365DaysRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp), intent(in) :: TmaxTnxReference365DaysRun_i
+    real(sp), intent(in) :: TmaxTnxReference365DaysRun_i
 
     TmaxTnxReference365DaysRun(i) = TmaxTnxReference365DaysRun_i
 end subroutine SetTmaxTnxReference365DaysRun_i
 
 
-real(dp) function GetTminTnxReference365Days()
+real(sp) function GetTminTnxReference365Days()
     !! Getter for the "TminTnxReference365Days" global variable.
 
     GetTminTnxReference365Days = TminTnxReference365Days
@@ -16306,13 +16307,13 @@ end function GetTminTnxReference365Days
 
 subroutine SetTminTnxReference365Days(TminTnxReference365Days_in)
     !! Setter for the "TminTnxReference365Days" global variable.
-    real(dp), intent(in) :: TminTnxReference365Days_in
+    real(sp), intent(in) :: TminTnxReference365Days_in
 
     TminTnxReference365Days = TminTnxReference365Days_in
 end subroutine SetTminTnxReference365Days
 
 
-real(dp) function GetTmaxTnxReference365Days()
+real(sp) function GetTmaxTnxReference365Days()
     !! Getter for the "TmaxTnxReference365Days" global variable.
 
     GetTmaxTnxReference365Days = TmaxTnxReference365Days
@@ -16321,7 +16322,7 @@ end function GetTmaxTnxReference365Days
 
 subroutine SetTmaxTnxReference365Days(TmaxTnxReference365Days_in)
     !! Setter for the "TmaxTnxReference365Days" global variable.
-    real(dp), intent(in) :: TmaxTnxReference365Days_in
+    real(sp), intent(in) :: TmaxTnxReference365Days_in
 
     TmaxTnxReference365Days = TmaxTnxReference365Days_in
 end subroutine SetTmaxTnxReference365Days
@@ -16330,7 +16331,7 @@ end subroutine SetTmaxTnxReference365Days
 
 function GetTminCropReferenceRun() result(TminCropReferenceRun_out)
     !! Getter for the "TminCropReferenceRun" global variable.
-    real(dp), dimension(1:365) :: TminCropReferenceRun_out
+    real(sp), dimension(1:365) :: TminCropReferenceRun_out
 
     TminCropReferenceRun_out = TminCropReferenceRun
 end function GetTminCropReferenceRun
@@ -16339,15 +16340,16 @@ end function GetTminCropReferenceRun
 function GetTminCropReferenceRun_i(i) result(TminCropReferenceRun_i)
     !! Getter for individual elements of the "GetTminCropReferenceRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp) :: TminCropReferenceRun_i
+    real(sp) :: TminCropReferenceRun_i
 
     TminCropReferenceRun_i = TminCropReferenceRun(i)
+    !TminCropReferenceRun_i = real(roundc(10000*real(TminCropReferenceRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTminCropReferenceRun_i
 
 
 subroutine SetTminCropReferenceRun(TminCropReferenceRun_in)
     !! Setter for the "TminCropReferenceRun" global variable.
-    real(dp), dimension(1:365), intent(in) :: TminCropReferenceRun_in
+    real(sp), dimension(1:365), intent(in) :: TminCropReferenceRun_in
 
     TminCropReferenceRun = TminCropReferenceRun_in
 end subroutine SetTminCropReferenceRun
@@ -16356,7 +16358,7 @@ end subroutine SetTminCropReferenceRun
 subroutine SetTminCropReferenceRun_i(i, TminCropReferenceRun_i)
     !! Setter for individual element for the "TminCropReferenceRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp), intent(in) :: TminCropReferenceRun_i
+    real(sp), intent(in) :: TminCropReferenceRun_i
 
     TminCropReferenceRun(i) = TminCropReferenceRun_i
 end subroutine SetTminCropReferenceRun_i
@@ -16365,7 +16367,7 @@ end subroutine SetTminCropReferenceRun_i
 
 function GetTmaxCropReferenceRun() result(TmaxCropReferenceRun_out)
     !! Getter for the "TmaxCropReferenceRun" global variable.
-    real(dp), dimension(1:365) :: TmaxCropReferenceRun_out
+    real(sp), dimension(1:365) :: TmaxCropReferenceRun_out
 
     TmaxCropReferenceRun_out = TmaxCropReferenceRun
 end function GetTmaxCropReferenceRun
@@ -16374,15 +16376,16 @@ end function GetTmaxCropReferenceRun
 function GetTmaxCropReferenceRun_i(i) result(TmaxCropReferenceRun_i)
     !! Getter for individual elements of the "GetTmaxCropReferenceRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp) :: TmaxCropReferenceRun_i
+    real(sp) :: TmaxCropReferenceRun_i
 
     TmaxCropReferenceRun_i = TmaxCropReferenceRun(i)
+    !TmaxCropReferenceRun_i = real(roundc(10000*real(TmaxCropReferenceRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTmaxCropReferenceRun_i
 
 
 subroutine SetTmaxCropReferenceRun(TmaxCropReferenceRun_in)
     !! Setter for the "TmaxCropReferenceRun" global variable.
-    real(dp), dimension(1:365), intent(in) :: TmaxCropReferenceRun_in
+    real(sp), dimension(1:365), intent(in) :: TmaxCropReferenceRun_in
 
     TmaxCropReferenceRun = TmaxCropReferenceRun_in
 end subroutine SetTmaxCropReferenceRun
@@ -16391,13 +16394,13 @@ end subroutine SetTmaxCropReferenceRun
 subroutine SetTmaxCropReferenceRun_i(i, TmaxCropReferenceRun_i)
     !! Setter for individual element for the "TmaxCropReferenceRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp), intent(in) :: TmaxCropReferenceRun_i
+    real(sp), intent(in) :: TmaxCropReferenceRun_i
 
     TmaxCropReferenceRun(i) = TmaxCropReferenceRun_i
 end subroutine SetTmaxCropReferenceRun_i
 
 
-real(dp) function GetTminCropReference()
+real(sp) function GetTminCropReference()
     !! Getter for the "TminCropReference" global variable.
 
     GetTminCropReference = TminCropReference
@@ -16406,13 +16409,13 @@ end function GetTminCropReference
 
 subroutine SetTminCropReference(TminCropReference_in)
     !! Setter for the "TminCropReference" global variable.
-    real(dp), intent(in) :: TminCropReference_in
+    real(sp), intent(in) :: TminCropReference_in
 
     TminCropReference = TminCropReference_in
 end subroutine SetTminCropReference
 
 
-real(dp) function GetTmaxCropReference()
+real(sp) function GetTmaxCropReference()
     !! Getter for the "TmaxCropReference" global variable.
 
     GetTmaxCropReference = TmaxCropReference
@@ -16421,7 +16424,7 @@ end function GetTmaxCropReference
 
 subroutine SetTmaxCropReference(TmaxCropReference_in)
     !! Setter for the "TmaxCropReference" global variable.
-    real(dp), intent(in) :: TmaxCropReference_in
+    real(sp), intent(in) :: TmaxCropReference_in
 
     TmaxCropReference = TmaxCropReference_in
 end subroutine SetTmaxCropReference
@@ -16430,7 +16433,7 @@ end subroutine SetTmaxCropReference
 
 function GetTminRun() result(TminRun_out)
     !! Getter for the "TminRun" global variable.
-    real(dp), dimension(1:366) :: TminRun_out
+    real(sp), dimension(1:366) :: TminRun_out
 
     TminRun_out = TminRun
 end function GetTminRun
@@ -16439,15 +16442,16 @@ end function GetTminRun
 function GetTminRun_i(i) result(TminRun_i)
     !! Getter for individual elements of the "GetTminRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp) :: TminRun_i
+    real(sp) :: TminRun_i
 
     TminRun_i = TminRun(i)
+    !TminRun_i = real(roundc(10000*real(TminRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTminRun_i
 
 
 subroutine SetTminRun(TminRun_in)
     !! Setter for the "TminRun" global variable.
-    real(dp), dimension(1:366), intent(in) :: TminRun_in
+    real(sp), dimension(1:366), intent(in) :: TminRun_in
 
     TminRun = TminRun_in
 end subroutine SetTminRun
@@ -16456,7 +16460,7 @@ end subroutine SetTminRun
 subroutine SetTminRun_i(i, TminRun_i)
     !! Setter for individual element for the "TminRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp), intent(in) :: TminRun_i
+    real(sp), intent(in) :: TminRun_i
 
     TminRun(i) = TminRun_i
 end subroutine SetTminRun_i
@@ -16465,7 +16469,7 @@ end subroutine SetTminRun_i
 
 function GetTmaxRun() result(TmaxRun_out)
     !! Getter for the "TmaxRun" global variable.
-    real(dp), dimension(1:366) :: TmaxRun_out
+    real(sp), dimension(1:366) :: TmaxRun_out
 
     TmaxRun_out = TmaxRun
 end function GetTmaxRun
@@ -16474,15 +16478,16 @@ end function GetTmaxRun
 function GetTmaxRun_i(i) result(TmaxRun_i)
     !! Getter for individual elements of the "GetTmaxRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp) :: TmaxRun_i
+    real(sp) :: TmaxRun_i
 
     TmaxRun_i = TmaxRun(i)
+    !TmaxRun_i = real(roundc(10000*real(TmaxRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTmaxRun_i
 
 
 subroutine SetTmaxRun(TmaxRun_in)
     !! Setter for the "TmaxRun" global variable.
-    real(dp), dimension(1:366), intent(in) :: TmaxRun_in
+    real(sp), dimension(1:366), intent(in) :: TmaxRun_in
 
     TmaxRun = TmaxRun_in
 end subroutine SetTmaxRun
@@ -16491,7 +16496,7 @@ end subroutine SetTmaxRun
 subroutine SetTmaxRun_i(i, TmaxRun_i)
     !! Setter for individual element for the "TmaxRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp), intent(in) :: TmaxRun_i
+    real(sp), intent(in) :: TmaxRun_i
 
     TmaxRun(i) = TmaxRun_i
 end subroutine SetTmaxRun_i
@@ -16531,7 +16536,7 @@ end subroutine SetTmax
 
 function GetTminTnxReference12MonthsRun() result(TminTnxReference12MonthsRun_out)
     !! Getter for the "TminTnxReference12MonthsRun" global variable.
-    real(dp), dimension(1:12) :: TminTnxReference12MonthsRun_out
+    real(sp), dimension(1:12) :: TminTnxReference12MonthsRun_out
 
     TminTnxReference12MonthsRun_out = TminTnxReference12MonthsRun
 end function GetTminTnxReference12MonthsRun
@@ -16540,7 +16545,7 @@ end function GetTminTnxReference12MonthsRun
 function GetTminTnxReference12MonthsRun_i(i) result(TminTnxReference12MonthsRun_i)
     !! Getter for individual elements of the "GetTminTnxReference12MonthsRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp) :: TminTnxReference12MonthsRun_i
+    real(sp) :: TminTnxReference12MonthsRun_i
 
     TminTnxReference12MonthsRun_i = TminTnxReference12MonthsRun(i)
 end function GetTminTnxReference12MonthsRun_i
@@ -16548,7 +16553,7 @@ end function GetTminTnxReference12MonthsRun_i
 
 subroutine SetTminTnxReference12MonthsRun(TminTnxReference12MonthsRun_in)
     !! Setter for the "TminTnxReference12MonthsRun" global variable.
-    real(dp), dimension(1:12), intent(in) :: TminTnxReference12MonthsRun_in
+    real(sp), dimension(1:12), intent(in) :: TminTnxReference12MonthsRun_in
 
     TminTnxReference12MonthsRun = TminTnxReference12MonthsRun_in
 end subroutine SetTminTnxReference12MonthsRun
@@ -16557,7 +16562,7 @@ end subroutine SetTminTnxReference12MonthsRun
 subroutine SetTminTnxReference12MonthsRun_i(i, TminTnxReference12MonthsRun_i)
     !! Setter for individual element for the "TminTnxReference12MonthsRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp), intent(in) :: TminTnxReference12MonthsRun_i
+    real(sp), intent(in) :: TminTnxReference12MonthsRun_i
 
     TminTnxReference12MonthsRun(i) = TminTnxReference12MonthsRun_i
 end subroutine SetTminTnxReference12MonthsRun_i
@@ -16566,7 +16571,7 @@ end subroutine SetTminTnxReference12MonthsRun_i
 
 function GetTmaxTnxReference12MonthsRun() result(TmaxTnxReference12MonthsRun_out)
     !! Getter for the "TmaxTnxReference12MonthsRun" global variable.
-    real(dp), dimension(1:12) :: TmaxTnxReference12MonthsRun_out
+    real(sp), dimension(1:12) :: TmaxTnxReference12MonthsRun_out
 
     TmaxTnxReference12MonthsRun_out = TmaxTnxReference12MonthsRun
 end function GetTmaxTnxReference12MonthsRun
@@ -16575,7 +16580,7 @@ end function GetTmaxTnxReference12MonthsRun
 function GetTmaxTnxReference12MonthsRun_i(i) result(TmaxTnxReference12MonthsRun_i)
     !! Getter for individual elements of the "GetTmaxTnxReference12MonthsRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp) :: TmaxTnxReference12MonthsRun_i
+    real(sp) :: TmaxTnxReference12MonthsRun_i
 
     TmaxTnxReference12MonthsRun_i = TmaxTnxReference12MonthsRun(i)
 end function GetTmaxTnxReference12MonthsRun_i
@@ -16583,7 +16588,7 @@ end function GetTmaxTnxReference12MonthsRun_i
 
 subroutine SetTmaxTnxReference12MonthsRun(TmaxTnxReference12MonthsRun_in)
     !! Setter for the "TmaxTnxReference12MonthsRun" global variable.
-    real(dp), dimension(1:12), intent(in) :: TmaxTnxReference12MonthsRun_in
+    real(sp), dimension(1:12), intent(in) :: TmaxTnxReference12MonthsRun_in
 
     TmaxTnxReference12MonthsRun = TmaxTnxReference12MonthsRun_in
 end subroutine SetTmaxTnxReference12MonthsRun
@@ -16592,7 +16597,7 @@ end subroutine SetTmaxTnxReference12MonthsRun
 subroutine SetTmaxTnxReference12MonthsRun_i(i, TmaxTnxReference12MonthsRun_i)
     !! Setter for individual element for the "TmaxTnxReference12MonthsRun" global variable.
     integer(int32), intent(in) :: i
-    real(dp), intent(in) :: TmaxTnxReference12MonthsRun_i
+    real(sp), intent(in) :: TmaxTnxReference12MonthsRun_i
 
     TmaxTnxReference12MonthsRun(i) = TmaxTnxReference12MonthsRun_i
 end subroutine SetTmaxTnxReference12MonthsRun_i

--- a/src/global.f90
+++ b/src/global.f90
@@ -31,6 +31,7 @@ real(dp), parameter :: CO2Ref = 369.41_dp;
 real(dp), parameter :: EvapZmin = 15._dp
     !! cm  minimum soil depth for water extraction by evaporation
 real(dp), parameter :: eps =10E-08
+real(dp), parameter :: ac_zero_threshold = 0.000001_dp
 real(dp), dimension(12), parameter :: ElapsedDays = [0._dp, 31._dp, 59.25_dp, &
                                                     90.25_dp, 120.25_dp, 151.25_dp, &
                                                     181.25_dp, 212.25_dp, 243.25_dp, &
@@ -1440,8 +1441,7 @@ real(dp) function CCiNoWaterStressSF(Dayi, L0, L12SF, L123, L1234, GDDL0,&
                                 SFRedCCX)
 
     ! Consider CDecline for limited soil fertiltiy
-    ! IF ((Dayi > L12SF) AND (SFCDecline > 0.000001))
-    if ((Dayi > L12SF) .and. (SFCDecline > 0.000001_dp) .and. (L12SF < L123)) then
+    if ((Dayi > L12SF) .and. (SFCDecline > ac_zero_threshold) .and. (L12SF < L123)) then
         if (Dayi < L123) then
             if (TheModeCycle == modeCycle_CalendarDays) then
                 CCi = CCi - (SFCDecline/100.0_dp)&
@@ -7981,7 +7981,7 @@ subroutine CalculateETpot(DAP, L0, L12, L123, LHarvest, DayLastCut, CCi, &
         end if
 
         ! Correction for Air temperature stress
-        if ((CCiAdjusted <= 0.000001_dp) &
+        if ((CCiAdjusted <= ac_zero_threshold) &
             .or. (roundc(GDDayi, mold=1) < 0)) then
             KsTrCold = 1._dp
         else

--- a/src/global.f90
+++ b/src/global.f90
@@ -1020,7 +1020,6 @@ integer(int32) :: IrriFirstDayNr
 integer(int32) :: ZiAqua ! Depth of Groundwater table below
                          ! soil surface in centimeter
 
-
 integer(int8) :: IniPercTAW ! Default Value for Percentage TAW for Initial
                             ! Soil Water Content Menu
 integer(int8) :: MaxPlotTr
@@ -16241,7 +16240,6 @@ function GetTminTnxReference365DaysRun_i(i) result(TminTnxReference365DaysRun_i)
     real(sp) :: TminTnxReference365DaysRun_i
 
     TminTnxReference365DaysRun_i = TminTnxReference365DaysRun(i)
-    !TminTnxReference365DaysRun_i = real(roundc(10000*real(TminTnxReference365DaysRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTminTnxReference365DaysRun_i
 
 
@@ -16277,7 +16275,6 @@ function GetTmaxTnxReference365DaysRun_i(i) result(TmaxTnxReference365DaysRun_i)
     real(sp) :: TmaxTnxReference365DaysRun_i
 
     TmaxTnxReference365DaysRun_i = TmaxTnxReference365DaysRun(i)
-    !TmaxTnxReference365DaysRun_i = real(roundc(10000*real(TmaxTnxReference365DaysRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTmaxTnxReference365DaysRun_i
 
 
@@ -16343,7 +16340,6 @@ function GetTminCropReferenceRun_i(i) result(TminCropReferenceRun_i)
     real(sp) :: TminCropReferenceRun_i
 
     TminCropReferenceRun_i = TminCropReferenceRun(i)
-    !TminCropReferenceRun_i = real(roundc(10000*real(TminCropReferenceRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTminCropReferenceRun_i
 
 
@@ -16379,7 +16375,6 @@ function GetTmaxCropReferenceRun_i(i) result(TmaxCropReferenceRun_i)
     real(sp) :: TmaxCropReferenceRun_i
 
     TmaxCropReferenceRun_i = TmaxCropReferenceRun(i)
-    !TmaxCropReferenceRun_i = real(roundc(10000*real(TmaxCropReferenceRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTmaxCropReferenceRun_i
 
 
@@ -16429,7 +16424,7 @@ subroutine SetTmaxCropReference(TmaxCropReference_in)
     TmaxCropReference = TmaxCropReference_in
 end subroutine SetTmaxCropReference
 
-! Tmin
+! TminRun
 
 function GetTminRun() result(TminRun_out)
     !! Getter for the "TminRun" global variable.
@@ -16465,7 +16460,7 @@ subroutine SetTminRun_i(i, TminRun_i)
     TminRun(i) = TminRun_i
 end subroutine SetTminRun_i
 
-! Tmax
+! TmaxRun
 
 function GetTmaxRun() result(TmaxRun_out)
     !! Getter for the "TmaxRun" global variable.
@@ -16481,7 +16476,6 @@ function GetTmaxRun_i(i) result(TmaxRun_i)
     real(sp) :: TmaxRun_i
 
     TmaxRun_i = TmaxRun(i)
-    !TmaxRun_i = real(roundc(10000*real(TmaxRun(i),kind=dp),mold=int32)/10000._sp,kind=sp)
 end function GetTmaxRun_i
 
 

--- a/src/inforesults.f90
+++ b/src/inforesults.f90
@@ -133,7 +133,7 @@ subroutine StatisticAnalysis(TypeObsSim, RangeObsMin, RangeObsMax, StrNr, &
         character(len=1024) :: buffer
         integer :: fOut
         integer(int8) :: Dayi, Monthi
-        integer(int32) :: SkipLines, NCi, NCobs, Yeari
+        integer(int32) :: SkipLines, NCobs, Yeari
         integer(int32) :: i, status
         real(dp) :: VarObsi, VarSimi, VarStdi
         real(dp), dimension(:), allocatable :: dummy_array

--- a/src/initialsettings.f90
+++ b/src/initialsettings.f90
@@ -374,9 +374,9 @@ subroutine InitializeSettings(use_default_soil_file,use_default_crop_file)
     ! 5. Climate
     ! 5.1 Temperature
     call SetTemperatureFile('(None)')
+    call SetTemperatureFilefull(GetTemperatureFile())  ! no file
     call SetTnxReferenceFile(GetTemperatureFile()) ! no file
     call SetTnxReferenceYear(2000) ! for refernce CO2 concentration
-    call SetTemperatureFilefull(GetTemperatureFile())  ! no file
     write(TempString1, '(f8.1)') GetSimulParam_Tmin()
     write(TempString2, '(f8.1)') GetSimulParam_Tmax()
     call SetTemperatureDescription('')

--- a/src/initialsettings.f90
+++ b/src/initialsettings.f90
@@ -3,6 +3,9 @@ module ac_initialsettings
 use ac_defaultcropsoil, only :  ResetDefaultSoil, &
                                 ResetDefaultCrop
 use ac_global, only:    SetSimulParam_PercRAW, &
+                        SetTnxReferenceFile, &
+                        SetTnxReferenceFileFull, &
+                        SetTnxReferenceYear, &
                         SetNrCompartments, &
                         SetSimulParam_CompDefThick, &
                         SetSimulParam_CropDay1, &
@@ -371,6 +374,8 @@ subroutine InitializeSettings(use_default_soil_file,use_default_crop_file)
     ! 5. Climate
     ! 5.1 Temperature
     call SetTemperatureFile('(None)')
+    call SetTnxReferenceFile(GetTemperatureFile()) ! no file
+    call SetTnxReferenceYear(2000) ! for refernce CO2 concentration
     call SetTemperatureFilefull(GetTemperatureFile())  ! no file
     write(TempString1, '(f8.1)') GetSimulParam_Tmin()
     write(TempString2, '(f8.1)') GetSimulParam_Tmax()

--- a/src/preparefertilitysalinity.f90
+++ b/src/preparefertilitysalinity.f90
@@ -1,0 +1,1151 @@
+module ac_preparefertilitysalinity
+
+use ac_global, only:    DaysInMonth, & 
+                        DetermineDate,&
+                        HarvestIndexGrowthCoefficient, &
+                        DegreesDay, &
+                        GetTnxReferenceYear,&
+                     GetTminCropReferenceRun, &
+                     SetTminCropReferenceRun, &
+                     GetTminCropReferenceRun_i, &
+                     SetTminCropReferenceRun_i, &
+                     GetTmaxCropReferenceRun, &
+                     SetTmaxCropReferenceRun, &
+                     GetTmaxCropReferenceRun_i, &
+                     SetTmaxCropReferenceRun_i, &
+                     GetTminTnxReference365DaysRun,&
+                     GetTmaxTnxReference365DaysRun,&
+                     GetTminTnxReference365DaysRun_i,&
+                     GetTmaxTnxReference365DaysRun_i,&
+                     SetTminTnxReference365DaysRun,&
+                     SetTmaxTnxReference365DaysRun,&
+                     SetTminTnxReference365DaysRun_i,&
+                     SetTmaxTnxReference365DaysRun_i,&
+                     FileExists, &
+                     undef_double, &
+                     undef_int, &
+                        CO2ref,&
+                        rep_DayEventDbl,&
+                        rep_Shapes,&
+                        rep_EffectStress,&
+                     Subkind_Forage, &
+                     subkind_Grain,  &
+                     subkind_Grain, &
+                     subkind_Tuber, &
+                     subkind_Vegetative, &
+                     modeCycle_CalendarDays, &
+                     modeCycle_GDDays, &
+                        LeapYear, &
+                        DetermineDayNr, &
+                        DetermineDayNr, &
+                        SplitStringInTwoParams, &
+                        SetSimulation_DelayedDays, &
+                        GetDaySwitchToLinear, &
+                        CropStressParametersSoilFertility, &
+                        TimeToMaxCanopySF, &
+                        GetPathNameSimul, &
+                        GetTemperatureRecord_ToY, &
+                        GetTemperatureRecord_FromY, &
+                        GetTemperatureRecord_ToM, &
+                        GetTemperatureRecord_FromM, &
+                        GetTemperatureRecord_ToDayNr, &
+                        GetTemperatureRecord_FromDayNr, &
+                        GetTemperatureRecord_DataType, &
+                        GetTemperatureFile, &
+                        GetTemperatureFilefull, &
+                        datatype_daily, &
+                        datatype_decadely, &
+                        SetTnxReferenceFile, &
+                        GetTnxReferenceFile, &
+                        SetTnxReferenceFileFull, &
+                        GetTnxReferenceFileFull, &
+                        GetSimulParam_GDDMethod, &
+                        GetCO2FileFull, &
+                        SeasonalSumOfKcPot, &
+                        DaysToReachCCwithGivenCGC
+
+use ac_kinds, only: dp, &
+                    int8, &
+                    int16, &
+                    int32, &
+                    intEnum, &
+                    sp
+use ac_tempprocessing, only: GDDCDCToCDC, &
+                        GrowingDegreeDays, &
+                        Bnormalized, &
+                        fTnxReference_open, &
+                        fTnxReference_write, & 
+                        fTnxReference_close,&
+                             CropStressParametersSoilSalinity
+
+use ac_project_input, only: GetNumberSimulationRuns, &
+                            ProjectInput
+use ac_utils, only: roundc, &
+                    GetReleaseDate, &
+                    GetVersionString, &
+                    trunc
+use iso_fortran_env, only: iostat_end
+implicit none
+
+
+contains
+
+
+
+
+integer(int32) function SumCalendarDaysReferenceTnx(ValGDDays, RefCropDay1,&
+                                        StartDayNr, Tbase, Tupper,&
+                                        TDayMin, TDayMax)
+    integer(int32), intent(in) :: ValGDDays
+    integer(int32), intent(in) :: RefCropDay1
+    integer(int32), intent(in) :: StartDayNr
+    real(dp), intent(in) :: Tbase
+    real(dp), intent(in) :: Tupper
+    real(dp), intent(in) :: TDayMin
+    real(dp), intent(in) :: TDayMax
+
+    integer(int32) :: i
+    integer(int32) :: NrCDays
+    real(dp) :: RemainingGDDays, DayGDD
+    
+    real(dp) :: TDayMin_loc, TDayMax_loc
+    
+    TDayMin_loc = TDayMin
+    TDayMax_loc = TDayMax
+
+    NrCdays = 0
+    if (ValGDDays > 0) then
+        if (GetTnxReferenceFile() == '(None)') then
+            ! given average Tmin and Tmax
+            DayGDD = DegreesDay(Tbase, Tupper, &
+                       TDayMin_loc, TDayMax_loc, GetSimulParam_GDDMethod())
+            if (abs(DayGDD) < epsilon(1._dp)) then
+                NrCDays = 0
+            else
+                NrCDays = roundc(ValGDDays/DayGDD, mold=1_int32)
+            end if
+        !else if (GetTemperatureFile() == '(External)') then
+        !    RemainingGDDays = ValGDDays
+        !    i = GetCrop_Day1()-GetSimulation_FromDayNr()+1
+        !    TDayMin_loc = real(GetTminRun_i(i),kind=dp)
+        !    TDayMax_loc = real(GetTmaxRun_i(i),kind=dp)
+        !    DayGDD = DegreesDay(Tbase, Tupper, TDayMin_loc, &
+        !                                TDayMax_loc, &
+        !                                GetSimulParam_GDDMethod())
+        !    NrCDays = NrCDays + 1
+        !    RemainingGDDays = RemainingGDDays - DayGDD
+        !
+        !    do while ((RemainingGDDays > 0) &
+        !                   .and. (i < (GetSimulation_ToDayNr()-GetSimulation_FromDayNr()+1)))
+        !          i = i + 1
+        !          TDayMin_loc = real(GetTminRun_i(i),kind=dp)
+        !          TDayMax_loc = real(GetTmaxRun_i(i),kind=dp)
+        ! 
+        !          DayGDD = DegreesDay(Tbase, Tupper, TDayMin_loc, &
+        !                               TDayMax_loc, &
+        !                               GetSimulParam_GDDMethod())
+        !          NrCDays = NrCDays + 1
+        !          RemainingGDDays = RemainingGDDays - DayGDD
+        !    end do
+        !
+        !    if (RemainingGDDays > 0) then
+        !        NrCDays = undef_int
+        !    end if
+        else
+            ! open TCropReference.SIM : mean daily Tnx (365 days) from RefCropDay1 onwards
+            ! determine corresponding calendar days
+            RemainingGDDays = ValGDDays
+
+            ! TminCropReference and TmaxCropReference arrays contain the TemperatureFilefull data
+            i = StartDayNr - RefCropDay1
+
+            do while (RemainingGDDays > 0.1_dp)
+                i = i + 1
+                if (i == size(GetTminCropReferenceRun())) then
+                    i = 1
+                end if
+                TDayMin_loc = GetTminCropReferenceRun_i(i)
+                TDayMax_loc = GetTmaxCropReferenceRun_i(i)
+
+                DayGDD = DegreesDay(Tbase, Tupper, TDayMin_loc, &
+                                    TDayMax_loc, &
+                                    GetSimulParam_GDDMethod())
+            WRITE(*, '(A, f10.6)') 'The value of RemainingGDDays is:', RemainingGDDays
+            WRITE(*, '(A, I4)') 'The value of StartDayNr is:', StartDayNr
+            WRITE(*, '(A, I4)') 'The value of RefCropDay1 is:', RefCropDay1
+            WRITE(*, '(A, f10.2)') 'TDayMin_loc:', TDayMin_loc
+            WRITE(*, '(A, f10.8)') 'The value of DayGDD is:', DayGDD
+                if (DayGDD > RemainingGDDays) then
+                    if (roundc((DayGDD-RemainingGDDays)/RemainingGDDays,mold=1) >= 1) then
+                        NrCDays = NrCDays + 1
+                    end if
+                else
+                    NrCDays = NrCDays + 1
+                end if
+            WRITE(*, '(A, i4)') 'The value of NrCDays is:', NrCDays
+                RemainingGDDays = RemainingGDDays - DayGDD
+            end do
+        end if
+    end if
+    SumCalendarDaysReferenceTnx = NrCDays
+    WRITE(*, *) 'End of SumCalendarDaysReference'
+end function SumCalendarDaysReferenceTnx
+
+
+
+
+subroutine AdjustCalendarDaysReferenceTnx(PlantDayNr, TheCropType, &
+        Tbase, Tupper, TDayMin, TDayMax, &
+        GDDL0, GDDL12, GDDFlor, GDDLengthFlor, GDDL123, &
+        GDDL1234, GDDHImax, GDDCGC, GDDCDC, &
+        CCo, CCx, RefHI, TheDaysToCCini, TheGDDaysToCCini, &
+        ThePlanting, L0, L12, LFlor, LengthFlor, &
+        L123, L1234, LHImax, CGC, CDC, RatedHIdt)
+    integer(int32), intent(in) :: PlantDayNr
+    integer(intEnum), intent(in) :: TheCropType
+    real(dp), intent(in) :: Tbase
+    real(dp), intent(in) :: Tupper
+    real(dp), intent(in) :: TDayMin
+    real(dp), intent(in) :: TDayMax
+    integer(int32), intent(in) :: GDDL0
+    integer(int32), intent(in) :: GDDL12
+    integer(int32), intent(in) :: GDDFlor
+    integer(int32), intent(in) :: GDDLengthFlor
+    integer(int32), intent(in) :: GDDL123
+    integer(int32), intent(in) :: GDDL1234
+    integer(int32), intent(in) :: GDDHImax
+    real(dp), intent(in) :: GDDCGC
+    real(dp), intent(in) :: GDDCDC
+    real(dp), intent(in) :: CCo
+    real(dp), intent(in) :: CCx
+    integer(int32), intent(in) :: RefHI
+    integer(int32), intent(in) :: TheDaysToCCini
+    integer(int32), intent(in) :: TheGDDaysToCCini
+    integer(intEnum), intent(in) :: ThePlanting
+    integer(int32), intent(inout) :: L0
+    integer(int32), intent(inout) :: L12
+    integer(int32), intent(inout) :: LFlor
+    integer(int32), intent(inout) :: LengthFlor
+    integer(int32), intent(inout) :: L123
+    integer(int32), intent(inout) :: L1234
+    integer(int32), intent(inout) :: LHImax
+    real(dp), intent(inout) :: CGC
+    real(dp), intent(inout) :: CDC
+    real(dp), intent(inout) :: RatedHIdt
+
+    integer(int32) :: ExtraGDDays, ExtraDays
+
+    if (TheDaysToCCini == 0) then
+        ! planting/sowing
+        L0 = SumCalendarDaysReferenceTnx(GDDL0, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+        L12 = SumCalendarDaysReferenceTnx(GDDL12, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+    else
+        ! regrowth
+        if (TheDaysToCCini > 0) then
+            ! CCini < CCx
+            ExtraGDDays = GDDL12 - GDDL0 - TheGDDaysToCCini
+            ExtraDays = SumCalendarDaysReferenceTnx(ExtraGDDays, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+            L12 = L0 + TheDaysToCCini + ExtraDays
+        end if
+    end if
+    if (TheCropType /= subkind_Forage) then
+        L123 = SumCalendarDaysReferenceTnx(GDDL123, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+        L1234 = SumCalendarDaysReferenceTnx(GDDL1234, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+    end if
+
+    select case (TheCropType)
+    case (subkind_Grain, subkind_Tuber)
+        LFlor = SumCalendarDaysReferenceTnx(GDDFlor, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+        if (TheCropType == subkind_Grain) then
+            LengthFlor = SumCalendarDaysReferenceTnx(GDDLengthFlor, PlantDayNr, (PlantDayNr+LFlor), Tbase, Tupper, TDayMin, TDayMax)
+        else
+            LengthFlor = 0
+        end if
+        LHImax = SumCalendarDaysReferenceTnx(GDDHImax, PlantDayNr, (PlantDayNr+LFlor), Tbase, Tupper, TDayMin, TDayMax)
+    case (subkind_Vegetative, subkind_Forage)
+        LHImax = SumCalendarDaysReferenceTnx(GDDHImax, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+    end select
+
+    CGC = (real(GDDL12, kind=dp)/real(L12, kind=dp)) * GDDCGC
+    call GDDCDCToCDC(PlantDayNr, L123, GDDL123, GDDL1234, CCx, GDDCDC, Tbase, Tupper, TDayMin, TDayMax, CDC)
+    if ((TheCropType == subkind_Grain) .or. (TheCropType == subkind_Tuber)) then
+        RatedHIdt = real(RefHI, kind=dp)/real(LHImax, kind=dp)
+    end if
+    if ((TheCropType == subkind_Vegetative) .or. (TheCropType == subkind_Forage)) then
+        if (LHImax > 0) then
+            if (LHImax > L1234) then
+                RatedHIdt = real(RefHI, kind=dp)/real(L1234, kind=dp)
+            else
+                RatedHIdt = real(RefHI, kind=dp)/real(LHImax, kind=dp)
+            end if
+            if (RatedHIdt > 100._dp) then
+                RatedHIdt = 100._dp ! 100 is maximum TempdHIdt (See SetdHIdt)
+                LHImax = 0
+            end if
+        else
+            RatedHIdt = 100._dp ! 100 is maximum TempdHIdt (See SetdHIdt)
+            LHImax = 0
+        end if
+    end if
+end subroutine AdjustCalendarDaysReferenceTnx
+
+
+
+
+
+subroutine DailyTnxReferenceFileCoveringCropPeriod(CropFirstDay)
+    integer(int32), intent(in) :: CropFirstDay
+
+    integer(int32) :: DayNr1
+    integer(int32) :: Dayi, Monthi, Yeari, i
+    real(dp) :: Tlow, Thigh
+    character(len=1025) :: TempString
+
+    if (FileExists(GetTnxReferenceFileFull())) then
+        ! CropFirstDay = DayNr1 in undefined year
+        call DetermineDate(CropFirstDay, Dayi, Monthi, Yeari)
+        call DetermineDayNr(Dayi, Monthi, (1901), DayNr1)
+        
+        ! create SIM file and record first day
+
+        call fTnxReference_open(trim(GetPathNameSimul()) // 'TCropReference.SIM','w')
+        
+        !WRITE(*, '(A, i4)') 'DayNr1:', DayNr1
+        !WRITE(*, '(A, f10.2)') 'Tlow:', GetTminTnxReference365DaysRun_i(DayNr1)
+
+        i = 0
+        do Dayi = DayNr1, 365
+            i=i+1
+            Tlow = GetTminTnxReference365DaysRun_i(Dayi)
+            Thigh = GetTmaxTnxReference365DaysRun_i(Dayi)
+            write(TempString, '(f10.2, f10.2)') Tlow,Thigh
+            call SetTminCropReferenceRun_i(i,Tlow)
+            call SetTmaxCropReferenceRun_i(i,Thigh)
+            call fTnxReference_write(trim(TempString))
+        end do
+        do Dayi = 1, (DayNr1-1)
+            i=i+1
+            Tlow = GetTminTnxReference365DaysRun_i(Dayi)
+            Thigh = GetTmaxTnxReference365DaysRun_i(Dayi)
+            write(TempString, '(f10.2, f10.2)') Tlow,Thigh
+            call SetTminCropReferenceRun_i(i,Tlow)
+            call SetTmaxCropReferenceRun_i(i,Thigh)
+            call fTnxReference_write(trim(TempString))
+        end do
+        
+        ! Close files
+        call fTnxReference_close()
+    end if
+end subroutine DailyTnxReferenceFileCoveringCropPeriod
+
+
+
+real(dp) function CO2ForTnxReferenceYear(TnxReferenceYear)
+    integer(int32), intent(in) :: TnxReferenceYear
+
+    integer(int32) :: i
+    integer(int32) :: fhandle, rc
+    character(len=1025) :: TempString
+    real(dp) :: TheCO2, CO2a, CO2b, YearA, YearB
+
+    if (TnxReferenceYear == 2000) then
+        TheCO2 = CO2Ref
+    else
+        open(newunit=fhandle, file=trim(GetCO2FileFull()), status='old', &
+                                                    action='read',iostat=rc)
+        do i= 1, 3
+            read(fhandle, *, iostat=rc) ! Description and Title
+        end do
+        ! from year
+        read(fhandle, '(a)', iostat=rc) TempString
+            !WRITE(*, *) 'TempString'
+            !WRITE(*, *) TempString
+        call SplitStringInTwoParams(trim(TempString), YearB, CO2b)
+        if (roundc(YearB, mold=1) >= TnxReferenceYear) then
+            TheCO2 = CO2b
+        else
+            loop: do
+                YearA = YearB
+                CO2a = CO2b
+                read(fhandle, '(a)', iostat=rc) TempString
+                call SplitStringInTwoParams(trim(TempString), YearB, CO2b)
+                if ((roundc(YearB, mold=1) >= TnxReferenceYear) .or. (rc == iostat_end)) exit loop
+            end do loop
+            if (TnxReferenceYear > roundc(YearB, mold=1)) then
+                TheCO2 = CO2b
+            else
+                TheCO2 = CO2a + (CO2b-CO2a)*(TnxReferenceYear - &
+                    roundc(YearA, mold=1))/(roundc(YearB, mold=1) - &
+                    roundc(YearA, mold=1))
+            end if
+        end if
+        Close(fhandle)
+    end if
+    CO2ForTnxReferenceYear = TheCO2
+end function CO2ForTnxReferenceYear
+
+
+subroutine StressBiomassRelationshipForTnxReference(TheDaysToCCini, TheGDDaysToCCini,&
+            L0, L12, L123, L1234, LFlor, LengthFlor, GDDL0, GDDL12,&
+            GDDL123, GDDL1234, WPyield, RefHI, CCo, CCx, CGC, GDDCGC,&
+            CDC, GDDCDC, KcTop, KcDeclAgeing, CCeffectProcent,&
+            Tbase, Tupper, TDayMin, TDayMax, GDtranspLow, WPveg, RatedHIdt,&
+            CO2TnxReferenceYear, RefCropDay1, CropDeterm, CropSResp, TheCropType,&
+            TheModeCycle, b0, b1, b2, &
+            BM10, BM20, BM30, BM40, BM50, BM60, BM70)
+    integer(int32), intent(in) :: TheDaysToCCini
+    integer(int32), intent(in) :: TheGDDaysToCCini
+    integer(int32), intent(in) :: L0
+    integer(int32), intent(in) :: L12
+    integer(int32), intent(in) :: L123
+    integer(int32), intent(in) :: L1234
+    integer(int32), intent(in) :: LFlor
+    integer(int32), intent(in) :: LengthFlor
+    integer(int32), intent(in) :: GDDL0
+    integer(int32), intent(in) :: GDDL12
+    integer(int32), intent(in) :: GDDL123
+    integer(int32), intent(in) :: GDDL1234
+    integer(int32), intent(in) :: WPyield
+    integer(int32), intent(in) :: RefHI
+    real(dp), intent(in) :: CCo
+    real(dp), intent(in) :: CCx
+    real(dp), intent(in) :: CGC
+    real(dp), intent(in) :: GDDCGC
+    real(dp), intent(in) :: CDC
+    real(dp), intent(in) :: GDDCDC
+    real(dp), intent(in) :: KcTop
+    real(dp), intent(in) :: KcDeclAgeing
+    real(dp), intent(in) :: CCeffectProcent
+    real(dp), intent(in) :: Tbase
+    real(dp), intent(in) :: Tupper
+    real(dp), intent(in) :: TDayMin
+    real(dp), intent(in) :: TDayMax
+    real(dp), intent(in) :: GDtranspLow
+    real(dp), intent(in) :: WPveg
+    real(dp), intent(in) :: RatedHIdt
+    real(dp), intent(in) :: CO2TnxReferenceYear
+    integer(int32), intent(in) :: RefCropDay1
+    logical, intent(in) :: CropDeterm
+    type(rep_Shapes), intent(in) :: CropSResp
+    integer(intEnum), intent(in) :: TheCropType
+    integer(intEnum), intent(in) :: TheModeCycle
+    real(dp), intent(inout) :: b0
+    real(dp), intent(inout) :: b1
+    real(dp), intent(inout) :: b2
+    real(dp), intent(inout) :: BM10
+    real(dp), intent(inout) :: BM20
+    real(dp), intent(inout) :: BM30
+    real(dp), intent(inout) :: BM40
+    real(dp), intent(inout) :: BM50
+    real(dp), intent(inout) :: BM60
+    real(dp), intent(inout) :: BM70
+
+    type StressIndexes
+        integer(int32) :: StressProc
+            !! Undocumented
+        real(dp) :: BioMProc
+            !! Undocumented
+        real(dp) :: BioMSquare
+            !! Undocumented
+    end type StressIndexes
+
+    type(StressIndexes), dimension(8) :: StressMatrix
+    integer(int8) :: Si
+    integer(int32) :: L12SF, GDDL12SF
+    type(rep_EffectStress) :: StressResponse
+    real(dp) :: RatDGDD, BNor, BNor100, Yavg, X1avg, X2avg,&
+                y, x1, x2, x1y, x2y, x1Sq, x2Sq, x1x2, &
+                SUMx1y, SUMx2y, SUMx1Sq, SUMx2Sq, SUMx1x2
+    integer(int32) :: SiPr
+    real(dp) :: SumKcTop, HIGC, HIGClinear
+    integer(int32) :: DaysYieldFormation, tSwitch
+    real(dp) :: TDayMax_temp, TDayMin_temp
+
+    ! 1. initialize
+    call SetSimulation_DelayedDays(0) ! required for CalculateETpot
+    L12SF = L12 ! to calculate SumKcTop (no stress)
+    GDDL12SF = GDDL12 ! to calculate SumKcTop (no stress)
+    ! Maximum sum Kc (no stress)
+    SumKcTop = SeasonalSumOfKcPot(TheDaysToCCini, TheGDDaysToCCini,&
+        L0, L12, L123, L1234, GDDL0, GDDL12, GDDL123, GDDL1234,&
+        CCo, CCx, CGC, GDDCGC, CDC, GDDCDC, KcTop, KcDeclAgeing,&
+        CCeffectProcent, Tbase, Tupper, TDayMin, TDayMax, &
+        GDtranspLow, CO2TnxReferenceYear, TheModeCycle, .true.)
+
+    ! Get PercentLagPhase (for estimate WPi during yield formation)
+    if ((TheCropType == subkind_Tuber) .or. (TheCropType == subkind_grain)) then
+        ! DaysToFlowering corresponds with Tuberformation
+        DaysYieldFormation = roundc(RefHI/RatedHIdt, mold=1)
+        if (CropDeterm) then
+            HIGC = HarvestIndexGrowthCoefficient(real(RefHI, kind=dp), RatedHIdt)
+            call GetDaySwitchToLinear(RefHI, RatedHIdt, HIGC, tSwitch,&
+                  HIGClinear)
+        else
+            tSwitch = roundc(DaysYieldFormation/3._dp, mold=1)
+        end if
+    end if
+
+    ! 2. Biomass production for various stress levels
+    do Si = 1, 8
+        ! various stress levels
+        ! stress effect
+        SiPr = int(10*(Si-1), kind=int32)
+        StressMatrix(Si)%StressProc = SiPr
+        call CropStressParametersSoilFertility(CropSResp, SiPr, StressResponse)
+        ! adjusted length of Max canopy cover
+        RatDGDD = 1
+        if ((StressResponse%RedCCX == 0) .and. &
+            (StressResponse%RedCGC == 0))then
+            L12SF = L12
+            GDDL12SF = GDDL12
+        else
+            call TimeToMaxCanopySF(CCo, CGC, CCx, L0, L12, L123, LFlor,&
+                   LengthFlor, CropDeterm, L12SF, StressResponse%RedCGC,&
+                   StressResponse%RedCCX, SiPr)
+            if (TheModeCycle == modeCycle_GDDays) then
+                TDayMin_temp = TDayMin
+                TDayMax_temp = TDayMax
+                GDDL12SF = SumCalendarDaysReferenceTnx(L12SF, RefCropDay1, RefCropDay1, Tbase, Tupper,&
+                                 TDayMin_temp, TDayMax_temp)
+            end if
+            if ((TheModeCycle == modeCycle_GDDays) .and. (GDDL12SF < GDDL123)) then
+                RatDGDD = (L123-L12SF)*1._dp/(GDDL123-GDDL12SF)
+            end if
+        end if
+        ! biomass production
+        BNor = Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
+                L0, L12, L12SF, L123, L1234, LFlor,&
+                GDDL0, GDDL12, GDDL12SF, GDDL123, GDDL1234, WPyield, &
+                DaysYieldFormation, tSwitch, CCo, CCx, CGC, GDDCGC, CDC,&
+                GDDCDC, KcTop, KcDeclAgeing, CCeffectProcent, WPveg, CO2TnxReferenceYear,&
+                Tbase, Tupper, TDayMin, TDayMax, GDtranspLow, RatDGDD,&
+                SumKcTop, SiPr, StressResponse%RedCGC, StressResponse%RedCCX,&
+                StressResponse%RedWP, StressResponse%RedKsSto, 0_int8, 0 ,&
+                StressResponse%CDecline, -0.01_dp, TheModeCycle, .true.,&
+                .true.)
+        if (Si == 1) then
+            BNor100 = BNor
+            StressMatrix(1)%BioMProc = 100._dp
+        else
+            if (BNor100 > 0.00001_dp) then
+                StressMatrix(Si)%BioMProc = 100._dp * BNor/BNor100
+            else
+                StressMatrix(Si)%BioMProc = 100._dp
+            end if
+        end if
+        StressMatrix(Si)%BioMSquare =&
+             StressMatrix(Si)%BioMProc *&
+             StressMatrix(Si)%BioMProc
+        ! end stress level
+    end do
+
+    ! 5. Stress - Biomass relationship
+    Yavg = 0._dp
+    X1avg = 0._dp
+    X2avg = 0._dp
+    do Si = 1, 8
+        ! various stress levels
+        Yavg = Yavg + StressMatrix(Si)%StressProc
+        X1avg = X1avg + StressMatrix(Si)%BioMProc
+        X2avg = X2avg + StressMatrix(Si)%BioMSquare
+    end do
+    Yavg  = Yavg/8._dp
+    X1avg = X1avg/8._dp
+    X2avg = X2avg/8._dp
+    SUMx1y  = 0._dp
+    SUMx2y  = 0._dp
+    SUMx1Sq = 0._dp
+    SUMx2Sq = 0._dp
+    SUMx1x2 = 0._dp
+    do Si = 1, 8
+        ! various stress levels
+        y     = StressMatrix(Si)%StressProc - Yavg
+        x1    = StressMatrix(Si)%BioMProc - X1avg
+        x2    = StressMatrix(Si)%BioMSquare - X2avg
+        x1y   = x1 * y
+        x2y   = x2 * y
+        x1Sq  = x1 * x1
+        x2Sq  = x2 * x2
+        x1x2  = x1 * x2
+        SUMx1y  = SUMx1y + x1y
+        SUMx2y  = SUMx2y + x2y
+        SUMx1Sq = SUMx1Sq + x1Sq
+        SUMx2Sq = SUMx2Sq + x2Sq
+        SUMx1x2 = SUMx1x2 + x1x2
+    end do
+
+    if (abs(roundc(SUMx1x2*1000._dp, mold=1)) /= 0) then
+        b2 = (SUMx1y - (SUMx2y * SUMx1Sq)/SUMx1x2)/&
+             (SUMx1x2 - (SUMx1Sq * SUMx2Sq)/SUMx1x2)
+        b1 = (SUMx1y - b2 * SUMx1x2)/SUMx1Sq
+        b0 = Yavg - b1*X1avg - b2*X2avg
+
+        BM10 =  StressMatrix(2)%BioMProc
+        BM20 =  StressMatrix(3)%BioMProc
+        BM30 =  StressMatrix(4)%BioMProc
+        BM40 =  StressMatrix(5)%BioMProc
+        BM50 =  StressMatrix(6)%BioMProc
+        BM60 =  StressMatrix(7)%BioMProc
+        BM70 =  StressMatrix(8)%BioMProc
+    else
+        b2 = real(undef_int, kind=dp)
+        b1 = real(undef_int, kind=dp)
+        b0 = real(undef_int, kind=dp)
+    end if
+end subroutine StressBiomassRelationshipForTnxReference
+
+
+subroutine CCxSaltStressRelationshipForTnxReference(TheDaysToCCini, TheGDDaysToCCini,&
+       L0, L12, L123, L1234, LFlor, LengthFlor, GDDFlor, GDDLengthFlor,&
+       GDDL0, GDDL12, GDDL123, GDDL1234, WPyield, RefHI, CCo, CCx, CGC,&
+       GDDCGC, CDC, GDDCDC, KcTop, KcDeclAgeing, CCeffectProcent, Tbase,&
+       Tupper, TDayMin, TDayMax, GDbioLow, WPveg, RatedHIdt, CO2TnxReferenceYear,&
+       CropDNr1, CropDeterm, TheCropType, TheModeCycle, TheCCsaltDistortion,&
+       Coeffb0Salt, Coeffb1Salt, Coeffb2Salt, Salt10, Salt20, Salt30,&
+       Salt40, Salt50, Salt60, Salt70, Salt80, Salt90)
+    integer(int32), intent(in) :: TheDaysToCCini
+    integer(int32), intent(in) :: TheGDDaysToCCini
+    integer(int32), intent(in) :: L0
+    integer(int32), intent(in) :: L12
+    integer(int32), intent(in) :: L123
+    integer(int32), intent(in) :: L1234
+    integer(int32), intent(in) :: LFlor
+    integer(int32), intent(in) :: LengthFlor
+    integer(int32), intent(in) :: GDDFlor
+    integer(int32), intent(in) :: GDDLengthFlor
+    integer(int32), intent(in) :: GDDL0
+    integer(int32), intent(in) :: GDDL12
+    integer(int32), intent(in) :: GDDL123
+    integer(int32), intent(in) :: GDDL1234
+    integer(int32), intent(in) :: WPyield
+    integer(int32), intent(in) :: RefHI
+    real(dp), intent(in) :: CCo
+    real(dp), intent(in) :: CCx
+    real(dp), intent(in) :: CGC
+    real(dp), intent(in) :: GDDCGC
+    real(dp), intent(in) :: CDC
+    real(dp), intent(in) :: GDDCDC
+    real(dp), intent(in) :: KcTop
+    real(dp), intent(in) :: KcDeclAgeing
+    real(dp), intent(in) :: CCeffectProcent
+    real(dp), intent(in) :: Tbase
+    real(dp), intent(in) :: Tupper
+    real(dp), intent(in) :: TDayMin
+    real(dp), intent(in) :: TDayMax
+    real(dp), intent(in) :: GDbioLow
+    real(dp), intent(in) :: WPveg
+    real(dp), intent(in) :: RatedHIdt
+    real(dp), intent(in) :: CO2TnxReferenceYear
+    integer(int32), intent(in) :: CropDNr1
+    logical, intent(in) :: CropDeterm
+    integer(intEnum), intent(in) :: TheCropType
+    integer(intEnum), intent(in) :: TheModeCycle
+    integer(int8), intent(in) :: TheCCsaltDistortion
+    real(dp), intent(inout) :: Coeffb0Salt
+    real(dp), intent(inout) :: Coeffb1Salt
+    real(dp), intent(inout) :: Coeffb2Salt
+    real(dp), intent(inout) :: Salt10
+    real(dp), intent(inout) :: Salt20
+    real(dp), intent(inout) :: Salt30
+    real(dp), intent(inout) :: Salt40
+    real(dp), intent(inout) :: Salt50
+    real(dp), intent(inout) :: Salt60
+    real(dp), intent(inout) :: Salt70
+    real(dp), intent(inout) :: Salt80
+    real(dp), intent(inout) :: Salt90
+
+    type StressIndexes
+        integer(int32) :: CCxReduction
+            !! Undocumented
+        real(dp) :: SaltProc
+            !! Undocumented
+        real(dp) :: SaltSquare
+            !! Undocumented
+    end type StressIndexes
+
+    integer(int32) :: L12SS, GDDL12SS, DaysYieldFormation, tSwitch
+    real(dp) :: SumKcTop, HIGC, HIGClinear, CCToReach
+    integer(int32) :: Si, SiPr
+    type(StressIndexes), dimension(10) :: StressMatrix
+    type(rep_EffectStress) :: StressResponse
+    real(dp) :: RatDGDD, BNor, BNor100, BioMProc
+    real(dp) :: Yavg, X1avg, X2avg, SUMx1y, SUMx2y, SUMx1Sq, &
+         SUMx2Sq, SUMx1x2, y, x1, x2, x1y, x2y, x1Sq, x2Sq, x1x2
+    real(dp) :: TDayMax_temp, TDayMin_temp
+
+    ! 1. initialize
+    call SetSimulation_DelayedDays(0) ! required for CalculateETpot
+    GDDL12SS = GDDL12 ! to calculate SumKcTop (no stress)
+    BNor100 = real(undef_int, kind=dp)
+    ! Maximum sum Kc (no stress)
+    SumKcTop = SeasonalSumOfKcPot(TheDaysToCCini, TheGDDaysToCCini,&
+        L0, L12, L123, L1234, GDDL0, GDDL12, GDDL123, GDDL1234,&
+        CCo, CCx, CGC, GDDCGC, CDC, GDDCDC, KcTop, KcDeclAgeing, &
+        CCeffectProcent,Tbase, Tupper, TDayMin, TDayMax, GDbioLow, &
+        CO2TnxReferenceYear, TheModeCycle, .true.)
+    ! Get PercentLagPhase (for estimate WPi during yield formation)
+    if ((TheCropType == subkind_Tuber) .or. (TheCropType == subkind_grain)) then
+        ! DaysToFlowering corresponds with Tuberformation
+        DaysYieldFormation = roundc(RefHI/RatedHIdt, mold=1)
+        if (CropDeterm) then
+            HIGC = HarvestIndexGrowthCoefficient(real(RefHI, kind=dp), RatedHIdt)
+            call GetDaySwitchToLinear(RefHI, RatedHIdt, &
+                    HIGC, tSwitch, HIGClinear)
+        else
+            tSwitch = roundc(DaysYieldFormation/3._dp, mold=1)
+        end if
+    end if
+
+    ! 2. Biomass production (or Salt stress) for various CCx reductions
+    do Si = 1, 10
+        ! various CCx reduction
+        ! CCx reduction
+        SiPr = int(10*(Si-1), kind=int32)
+        StressMatrix(Si)%CCxReduction = int(SiPr, kind=int8)
+        ! adjustment CC
+        call CropStressParametersSoilSalinity(int(SiPr, kind=int8), TheCCsaltDistortion, &
+            CCo, CCx, CGC, GDDCGC, CropDeterm, L12, LFlor, LengthFlor, L123,&
+            GDDL12, GDDFlor, GDDLengthFlor, GDDL123, TheModeCycle,&
+            StressResponse)
+        ! adjusted length of Max canopy cover
+        RatDGDD = 1
+        if ((StressResponse%RedCCX == 0) .and.&
+            (StressResponse%RedCGC == 0)) then
+            L12SS = L12
+            GDDL12SS = GDDL12
+        else
+            CCToReach = 0.98_dp*(1._dp-StressResponse%RedCCX/100._dp)*CCx
+            L12SS = DaysToReachCCwithGivenCGC(CCToReach, CCo, &
+                 (1._dp-StressResponse%RedCCX/100._dp)*CCx,&
+                 CGC*(1._dp-StressResponse%RedCGC/100._dp), L0)
+            if (TheModeCycle == modeCycle_GDDays) then
+                TDayMax_temp = TDayMax
+                TDayMin_temp = TDayMin
+                GDDL12SS = GrowingDegreeDays(L12SS, CropDNr1, Tbase, &
+                           Tupper, TDayMin_temp, TDayMax_temp)
+            end if
+            if ((TheModeCycle == modeCycle_GDDays) .and.&
+                (GDDL12SS < GDDL123)) then
+                RatDGDD = (L123-L12SS)*1._dp/(GDDL123-GDDL12SS)
+            end if
+        end if
+
+        ! biomass production
+        BNor = Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
+                L0, L12, L12SS, L123, L1234, LFlor,&
+                GDDL0, GDDL12, GDDL12SS, GDDL123, GDDL1234,&
+                WPyield, DaysYieldFormation, tSwitch,&
+                CCo, CCx, CGC, GDDCGC, CDC, GDDCDC,&
+                KcTop, KcDeclAgeing, CCeffectProcent, WPveg, CO2TnxReferenceYear,&
+                Tbase, Tupper, TDayMin, TDayMax, GDbioLow, RatDGDD, SumKcTop,&
+                SiPr, StressResponse%RedCGC, StressResponse%RedCCX,&
+                StressResponse%RedWP, StressResponse%RedKsSto, &
+                0_int8, 0, StressResponse%CDecline, -0.01_dp,&
+                TheModeCycle, .false., .true.)
+        if (Si == 1) then
+            BNor100 = BNor
+            BioMProc = 100._dp
+            StressMatrix(1)%SaltProc = 0._dp
+        else
+            if (BNor100 > 0.00001_dp) then
+                BioMProc = 100._dp * BNor/BNor100
+                StressMatrix(Si)%SaltProc = 100._dp - BioMProc
+            else
+                StressMatrix(Si)%SaltProc = 0._dp
+            end if
+        end if
+        StressMatrix(Si)%SaltSquare = &
+             StressMatrix(Si)%SaltProc *&
+             StressMatrix(Si)%SaltProc
+        ! end stress level
+    end do
+
+    ! 3. CCx - Salt stress relationship
+    Yavg = 0._dp
+    X1avg = 0._dp
+    X2avg = 0._dp
+    do Si = 1, 10
+        ! various CCx reduction
+        Yavg = Yavg + StressMatrix(Si)%CCxReduction
+        X1avg = X1avg + StressMatrix(Si)%SaltProc
+        X2avg = X2avg + StressMatrix(Si)%SaltSquare
+    end do
+    Yavg  = Yavg/10._dp
+    X1avg = X1avg/10._dp
+    X2avg = X2avg/10._dp
+    SUMx1y  = 0._dp
+    SUMx2y  = 0._dp
+    SUMx1Sq = 0._dp
+    SUMx2Sq = 0._dp
+    SUMx1x2 = 0._dp
+    do Si = 1, 10
+        ! various CCx reduction
+        y     = StressMatrix(Si)%CCxReduction - Yavg
+        x1    = StressMatrix(Si)%SaltProc - X1avg
+        x2    = StressMatrix(Si)%SaltSquare - X2avg
+        x1y   = x1 * y
+        x2y   = x2 * y
+        x1Sq  = x1 * x1
+        x2Sq  = x2 * x2
+        x1x2  = x1 * x2
+        SUMx1y  = SUMx1y + x1y
+        SUMx2y  = SUMx2y + x2y
+        SUMx1Sq = SUMx1Sq + x1Sq
+        SUMx2Sq = SUMx2Sq + x2Sq
+        SUMx1x2 = SUMx1x2 + x1x2
+    end do
+
+    if (abs(roundc(SUMx1x2*1000._dp, mold=1)) /= 0) then
+        Coeffb2Salt = (SUMx1y - (SUMx2y * SUMx1Sq)/SUMx1x2)/&
+                      (SUMx1x2 - (SUMx1Sq * SUMx2Sq)/SUMx1x2)
+        Coeffb1Salt = (SUMx1y - Coeffb2Salt * SUMx1x2)/SUMx1Sq
+        Coeffb0Salt = Yavg - Coeffb1Salt*X1avg - Coeffb2Salt*X2avg
+
+        Salt10 =  StressMatrix(2)%SaltProc
+        Salt20 =  StressMatrix(3)%SaltProc
+        Salt30 =  StressMatrix(4)%SaltProc
+        Salt40 =  StressMatrix(5)%SaltProc
+        Salt50 =  StressMatrix(5)%SaltProc
+        Salt60 =  StressMatrix(7)%SaltProc
+        Salt70 =  StressMatrix(8)%SaltProc
+        Salt80 =  StressMatrix(9)%SaltProc
+        Salt90 =  StressMatrix(10)%SaltProc
+    else
+        Coeffb2Salt = real(undef_int, kind=dp)
+        Coeffb1Salt = real(undef_int, kind=dp)
+        Coeffb0Salt = real(undef_int, kind=dp)
+    end if
+end subroutine CCxSaltStressRelationshipForTnxReference
+
+
+subroutine ReferenceStressBiomassRelationship(TheDaysToCCini, &
+        TheGDDaysToCCini, &
+        L0, L12, L123, L1234, LFlor, LengthFlor, GDDL0, GDDL12, &
+        GDDL123, GDDL1234, WPyield, RefHI, CCo, CCx, CGC, GDDCGC, &
+        CDC, GDDCDC, KcTop, KcDeclAgeing, CCeffectProcent, &
+        Tbase, Tupper, TDayMin, TDayMax, GDtranspLow, WPveg, RatedHIdt, &
+        CropDNr1, CropDeterm, CropSResp, TheCropType, &
+        TheModeCycle, b0, b1, b2, &
+        BM10, BM20, BM30, BM40, BM50, BM60, BM70, &
+        GDDFlor, GDDLengthFlor, GDDHImax, ThePlanting, LHImax)
+    integer(int32), intent(in) :: TheDaysToCCini
+    integer(int32), intent(in) :: TheGDDaysToCCini
+    integer(int32), intent(in) :: L0
+    integer(int32), intent(in) :: L12
+    integer(int32), intent(in) :: L123
+    integer(int32), intent(in) :: L1234
+    integer(int32), intent(in) :: LFlor
+    integer(int32), intent(in) :: LengthFlor
+    integer(int32), intent(in) :: GDDL0
+    integer(int32), intent(in) :: GDDL12
+    integer(int32), intent(in) :: GDDL123
+    integer(int32), intent(in) :: GDDL1234
+    integer(int32), intent(in) :: WPyield
+    integer(int32), intent(in) :: RefHI
+    real(dp), intent(in) :: CCo
+    real(dp), intent(in) :: CCx
+    real(dp), intent(in) :: CGC
+    real(dp), intent(in) :: GDDCGC
+    real(dp), intent(in) :: CDC
+    real(dp), intent(in) :: GDDCDC
+    real(dp), intent(in) :: KcTop
+    real(dp), intent(in) :: KcDeclAgeing
+    real(dp), intent(in) :: CCeffectProcent
+    real(dp), intent(in) :: Tbase
+    real(dp), intent(in) :: Tupper
+    real(dp), intent(in) :: TDayMin
+    real(dp), intent(in) :: TDayMax
+    real(dp), intent(in) :: GDtranspLow
+    real(dp), intent(in) :: WPveg
+    real(dp), intent(in) :: RatedHIdt
+    integer(int32), intent(in) :: CropDNr1
+    logical, intent(in) :: CropDeterm
+    type(rep_Shapes), intent(in) :: CropSResp
+    integer(intEnum), intent(in) :: TheCropType
+    integer(intEnum), intent(in) :: TheModeCycle
+    real(dp), intent(inout) :: b0
+    real(dp), intent(inout) :: b1
+    real(dp), intent(inout) :: b2
+    real(dp), intent(inout) :: BM10
+    real(dp), intent(inout) :: BM20
+    real(dp), intent(inout) :: BM30
+    real(dp), intent(inout) :: BM40
+    real(dp), intent(inout) :: BM50
+    real(dp), intent(inout) :: BM60
+    real(dp), intent(inout) :: BM70
+    integer(int32), intent(in) :: GDDFlor
+    integer(int32), intent(in) :: GDDLengthFlor
+    integer(int32), intent(in) :: GDDHImax
+    integer(intEnum), intent(in) :: ThePlanting
+    integer(int32), intent(in) :: LHImax
+
+
+
+    integer(int32) :: RefCropDay1
+    integer(int32) :: Dayi, Monthi, Yeari
+    real(dp) :: CO2TnxReferenceYear
+    integer(int32) :: L0_loc
+    integer(int32) :: L12_loc
+    integer(int32) :: L123_loc
+    integer(int32) :: L1234_loc
+    integer(int32) :: LFlor_loc
+    integer(int32) :: LengthFlor_loc
+    integer(int32) :: LHImax_loc
+    real(dp) :: CGC_loc
+    real(dp) :: CDC_loc
+    real(dp) :: RatedHIdt_loc
+
+
+
+    WRITE(*, '(I4)') TheDaysToCCini
+    WRITE(*, '(I4)') TheGDDaysToCCini
+    WRITE(*, '(I4)') L0
+    WRITE(*, '(I4)') L12
+    WRITE(*, '(I4)') L123
+    WRITE(*, '(I4)') L1234
+    WRITE(*, '(I4)') LFlor
+    WRITE(*, '(I4)') LengthFlor
+    WRITE(*, '(I4)') GDDL0
+    WRITE(*, '(I4)') GDDL12
+    WRITE(*, '(I4)') GDDL123
+    WRITE(*, '(I4)') GDDL1234
+    WRITE(*, '(I4)') WPyield
+    WRITE(*, '(I4)') RefHI
+    WRITE(*, '(f10.2)') CCo
+    WRITE(*, '(f10.2)') CCx
+    WRITE(*, '(f10.2)') CGC
+    WRITE(*, '(f10.2)') GDDCGC
+    WRITE(*, '(f10.2)') CDC
+    WRITE(*, '(f10.2)') GDDCDC
+    WRITE(*, '(f10.2)') KcTop
+    WRITE(*, '(f10.2)') KcDeclAgeing
+    WRITE(*, '(f10.2)') CCeffectProcent
+    WRITE(*, '(f10.2)') Tbase
+    WRITE(*, '(f10.2)') Tupper
+    WRITE(*, '(f10.2)') TDayMin
+    WRITE(*, '(f10.2)') TDayMax
+    WRITE(*, '(f10.2)') GDtranspLow
+    WRITE(*, '(f10.2)') WPveg
+    WRITE(*, '(f10.2)') RatedHIdt
+    WRITE(*, '(I6)') CropDNr1
+    !logical, intent(in) :: CropDeterm
+    !type(rep_Shapes), intent(in) :: CropSResp
+    WRITE(*, '(I4)') TheCropType
+    WRITE(*, '(I4)') TheModeCycle
+    WRITE(*, '(f10.2)') b0
+    WRITE(*, '(f10.2)') b1
+    WRITE(*, '(f10.2)') b2
+    WRITE(*, '(f10.2)') BM10
+    WRITE(*, '(f10.2)') BM20
+    WRITE(*, '(f10.2)') BM30
+    WRITE(*, '(f10.2)') BM40
+    WRITE(*, '(f10.2)') BM50
+    WRITE(*, '(f10.2)') BM60
+    WRITE(*, '(f10.2)') BM70
+    WRITE(*, '(I4)') GDDFlor
+    WRITE(*, '(I4)') GDDLengthFlor
+    WRITE(*, '(I4)') GDDHImax
+    WRITE(*, '(I4)') ThePlanting
+    WRITE(*, '(I4)') LHImax
+        L0_loc = L0
+        L12_loc = L12
+        LFlor_loc = LFlor
+        LengthFlor_loc = LengthFlor
+        L123_loc = L123
+        L1234_loc = L1234
+        LHImax_loc = LHImax
+        CGC_loc = CGC
+        CDC_loc =  CDC 
+        RatedHIdt_loc = RatedHIdt
+    
+
+
+    ! 1. Day 1 of the GrowingCycle
+    call DetermineDate(CropDNr1, Dayi, Monthi, Yeari)
+    call DetermineDayNr(Dayi, Monthi, (1901), RefCropDay1)  ! not linked to a specific year
+
+    ! 2. Create TCropReference.SIM (i.e. daily mean Tnx for 365 days from Onset onwards)
+    if (GetTnxReferenceFile() /= '(None)') then
+        call DailyTnxReferenceFileCoveringCropPeriod(RefCropDay1)
+    end if
+
+    ! 3. Determine coresponding calendar days if crop cycle is defined in GDDays
+    if (TheModeCycle == modeCycle_GDDays) then
+        call AdjustCalendarDaysReferenceTnx(RefCropDay1,&
+        TheCropType,&
+        Tbase, Tupper, TDayMin, TDayMax,&
+        GDDL0, GDDL12, GDDFlor, GDDLengthFlor, GDDL123, GDDL1234,&
+        GDDHImax,&
+        GDDCGC, GDDCDC, CCo, CCx,&
+        RefHI,&
+        TheDaysToCCini, TheGDDaysToCCini,&
+        ThePlanting,&
+        L0_loc, L12_loc, LFlor_loc, LengthFlor_loc, L123_loc, &
+        L1234_loc, LHImax_loc,&
+        CGC_loc, CDC_loc, RatedHIdt_loc)
+    end if
+
+    ! 4. CO2 concentration for TnxReferenceYear
+    if (GetTnxReferenceYear() == 2000) then
+        CO2TnxReferenceYear = CO2Ref
+    else
+        CO2TnxReferenceYear = CO2ForTnxReferenceYear(GetTnxReferenceYear())
+    end if
+
+    ! 5. Stress Biomass relationship
+    call StressBiomassRelationshipForTnxReference(TheDaysToCCini, TheGDDaysToCCini,&
+    L0_loc, L12_loc, L123_loc, L1234_loc,&
+    LFlor_loc, LengthFlor_loc,&
+    GDDL0, GDDL12, GDDL123, GDDL1234, WPyield, RefHI,&
+    CCo, CCx, CGC_loc, GDDCGC, CDC_loc, GDDCDC,&
+    KcTop, KcDeclAgeing, CCeffectProcent,&
+    Tbase, Tupper, TDayMin, TDayMax, GDtranspLow,&
+    WPveg, RatedHIdt_loc, CO2TnxReferenceYear,&
+    RefCropDay1,&
+    CropDeterm,&
+    CropSResp,&
+    TheCropType,&
+    TheModeCycle,&
+    b0, b1, b2,&
+    BM10, BM20, BM30, BM40, BM50, BM60, BM70)
+end subroutine ReferenceStressBiomassRelationship
+
+
+subroutine ReferenceCCxSaltStressRelationship(TheDaysToCCini, &
+        TheGDDaysToCCini, L0, L12, L123, L1234, LFlor, LengthFlor, &
+        GDDFlor, GDDLengthFlor, GDDL0, GDDL12, GDDL123, GDDL1234, &
+        WPyield, RefHI, CCo, CCx, CGC, GDDCGC, CDC, GDDCDC, KcTop, &
+        KcDeclAgeing, CCeffectProcent, Tbase, Tupper, TDayMin, &
+        TDayMax, GDbioLow, WPveg, RatedHIdt, CropDNr1, CropDeterm, &
+        TheCropType, TheModeCycle, TheCCsaltDistortion, Coeffb0Salt, &
+        Coeffb1Salt, Coeffb2Salt, Salt10, Salt20, Salt30, Salt40, &
+        Salt50, Salt60, Salt70, Salt80, Salt90, GDDHImax, &
+        ThePlanting, LHImax)
+    integer(int32), intent(in) :: TheDaysToCCini
+    integer(int32), intent(in) :: TheGDDaysToCCini
+    integer(int32), intent(in) :: L0
+    integer(int32), intent(in) :: L12
+    integer(int32), intent(in) :: L123
+    integer(int32), intent(in) :: L1234
+    integer(int32), intent(in) :: LFlor
+    integer(int32), intent(in) :: LengthFlor
+    integer(int32), intent(in) :: GDDFlor
+    integer(int32), intent(in) :: GDDLengthFlor
+    integer(int32), intent(in) :: GDDL0
+    integer(int32), intent(in) :: GDDL12
+    integer(int32), intent(in) :: GDDL123
+    integer(int32), intent(in) :: GDDL1234
+    integer(int32), intent(in) :: WPyield
+    integer(int32), intent(in) :: RefHI
+    real(dp), intent(in) :: CCo
+    real(dp), intent(in) :: CCx
+    real(dp), intent(in) :: CGC
+    real(dp), intent(in) :: GDDCGC
+    real(dp), intent(in) :: CDC
+    real(dp), intent(in) :: GDDCDC
+    real(dp), intent(in) :: KcTop
+    real(dp), intent(in) :: KcDeclAgeing
+    real(dp), intent(in) :: CCeffectProcent
+    real(dp), intent(in) :: Tbase
+    real(dp), intent(in) :: Tupper
+    real(dp), intent(in) :: TDayMin
+    real(dp), intent(in) :: TDayMax
+    real(dp), intent(in) :: GDbioLow
+    real(dp), intent(in) :: WPveg
+    real(dp), intent(in) :: RatedHIdt
+    integer(int32), intent(in) :: CropDNr1
+    logical, intent(in) :: CropDeterm
+    integer(intEnum), intent(in) :: TheCropType
+    integer(intEnum), intent(in) :: TheModeCycle
+    integer(int8), intent(in) :: TheCCsaltDistortion
+    real(dp), intent(inout) :: Coeffb0Salt
+    real(dp), intent(inout) :: Coeffb1Salt
+    real(dp), intent(inout) :: Coeffb2Salt
+    real(dp), intent(inout) :: Salt10
+    real(dp), intent(inout) :: Salt20
+    real(dp), intent(inout) :: Salt30
+    real(dp), intent(inout) :: Salt40
+    real(dp), intent(inout) :: Salt50
+    real(dp), intent(inout) :: Salt60
+    real(dp), intent(inout) :: Salt70
+    real(dp), intent(inout) :: Salt80
+    real(dp), intent(inout) :: Salt90
+    integer(int32), intent(in) :: GDDHImax
+    integer(intEnum), intent(in) :: ThePlanting
+    integer(int32), intent(in) :: LHImax
+
+    integer(int32) :: RefCropDay1
+    integer(int32) :: Dayi, Monthi, Yeari
+    real(dp) :: CO2TnxReferenceYear
+    integer(int32) :: L0_loc
+    integer(int32) :: L12_loc
+    integer(int32) :: L123_loc
+    integer(int32) :: L1234_loc
+    integer(int32) :: LFlor_loc
+    integer(int32) :: LengthFlor_loc
+    integer(int32) :: LHImax_loc
+    real(dp) :: CGC_loc
+    real(dp) :: CDC_loc
+    real(dp) :: RatedHIdt_loc
+
+    L0_loc = L0
+    L12_loc = L12
+    L123_loc = L123
+    L1234_loc = L1234
+    LFlor_loc = LFlor
+    LengthFlor_loc = LengthFlor
+    LHImax_loc = LHImax
+    CGC_loc = CGC
+    CDC_loc = CDC
+    RatedHIdt_loc = RatedHIdt
+
+    ! 1. Day 1 of the GrowingCycle
+    call DetermineDate(CropDNr1, Dayi, Monthi, Yeari)
+    call DetermineDayNr(Dayi, Monthi, (1901), RefCropDay1)  ! not linked to a specific year
+
+    ! 2. Create TCropReference.SIM (i.e. daily mean Tnx for 365 days from Onset onwards)
+    if (GetTnxReferenceFile() /= '(None)') then
+        call DailyTnxReferenceFileCoveringCropPeriod(RefCropDay1)
+    end if
+
+    ! 3. Determine coresponding calendar days if crop cycle is defined in GDDays
+    if (TheModeCycle == modeCycle_GDDays) then
+        call AdjustCalendarDaysReferenceTnx(RefCropDay1,&
+        TheCropType,&
+        Tbase, Tupper, TDayMin, TDayMax,&
+        GDDL0, GDDL12, GDDFlor, GDDLengthFlor, GDDL123, GDDL1234,&
+        GDDHImax,&
+        GDDCGC, GDDCDC, CCo, CCx,&
+        RefHI,&
+        TheDaysToCCini, TheGDDaysToCCini,&
+        ThePlanting,&
+        L0_loc, L12_loc, LFlor_loc, LengthFlor_loc, L123_loc, &
+        L1234_loc, LHImax_loc,&
+        CGC_loc, CDC_loc, RatedHIdt_loc)
+    end if
+
+    ! 4. CO2 concentration for TnxReferenceYear
+    if (GetTnxReferenceYear() == 2000) then
+        CO2TnxReferenceYear = CO2Ref
+    else
+        CO2TnxReferenceYear = CO2ForTnxReferenceYear(GetTnxReferenceYear())
+    end if
+
+    ! 5. Stress Biomass relationship for salinity
+    call CCxSaltStressRelationshipForTnxReference(TheDaysToCCini, TheGDDaysToCCini,&
+    L0_loc, L12_loc, L123_loc, L1234_loc,&
+    LFlor_loc, LengthFlor_loc, GDDFlor, GDDLengthFlor,&
+    GDDL0, GDDL12, GDDL123, GDDL1234, WPyield, RefHI,&
+    CCo, CCx, CGC_loc, GDDCGC, CDC_loc, GDDCDC,&
+    KcTop, KcDeclAgeing, CCeffectProcent,&
+    Tbase, Tupper, TDayMin, TDayMax, GDbioLow, WPveg, RatedHIdt_loc, CO2TnxReferenceYear,&
+    CropDNr1,&
+    CropDeterm,&
+    TheCropType,&
+    TheModeCycle,&
+    TheCCsaltDistortion,&
+    Coeffb0Salt, Coeffb1Salt, Coeffb2Salt,&
+    Salt10, Salt20, Salt30, Salt40, Salt50, Salt60, Salt70, Salt80, Salt90)
+end subroutine ReferenceCCxSaltStressRelationship
+
+end module ac_preparefertilitysalinity

--- a/src/preparefertilitysalinity.f90
+++ b/src/preparefertilitysalinity.f90
@@ -5,36 +5,36 @@ use ac_global, only:    DaysInMonth, &
                         HarvestIndexGrowthCoefficient, &
                         DegreesDay, &
                         GetTnxReferenceYear,&
-                     GetTminCropReferenceRun, &
-                     SetTminCropReferenceRun, &
-                     GetTminCropReferenceRun_i, &
-                     SetTminCropReferenceRun_i, &
-                     GetTmaxCropReferenceRun, &
-                     SetTmaxCropReferenceRun, &
-                     GetTmaxCropReferenceRun_i, &
-                     SetTmaxCropReferenceRun_i, &
-                     GetTminTnxReference365DaysRun,&
-                     GetTmaxTnxReference365DaysRun,&
-                     GetTminTnxReference365DaysRun_i,&
-                     GetTmaxTnxReference365DaysRun_i,&
-                     SetTminTnxReference365DaysRun,&
-                     SetTmaxTnxReference365DaysRun,&
-                     SetTminTnxReference365DaysRun_i,&
-                     SetTmaxTnxReference365DaysRun_i,&
-                     FileExists, &
-                     undef_double, &
-                     undef_int, &
+                        GetTminCropReferenceRun, &
+                        SetTminCropReferenceRun, &
+                        GetTminCropReferenceRun_i, &
+                        SetTminCropReferenceRun_i, &
+                        GetTmaxCropReferenceRun, &
+                        SetTmaxCropReferenceRun, &
+                        GetTmaxCropReferenceRun_i, &
+                        SetTmaxCropReferenceRun_i, &
+                        GetTminTnxReference365DaysRun,&
+                        GetTmaxTnxReference365DaysRun,&
+                        GetTminTnxReference365DaysRun_i,&
+                        GetTmaxTnxReference365DaysRun_i,&
+                        SetTminTnxReference365DaysRun,&
+                        SetTmaxTnxReference365DaysRun,&
+                        SetTminTnxReference365DaysRun_i,&
+                        SetTmaxTnxReference365DaysRun_i,&
+                        FileExists, &
+                        undef_double, &
+                        undef_int, &
                         CO2ref,&
                         rep_DayEventDbl,&
                         rep_Shapes,&
                         rep_EffectStress,&
-                     Subkind_Forage, &
-                     subkind_Grain,  &
-                     subkind_Grain, &
-                     subkind_Tuber, &
-                     subkind_Vegetative, &
-                     modeCycle_CalendarDays, &
-                     modeCycle_GDDays, &
+                        Subkind_Forage, &
+                        subkind_Grain,  &
+                        subkind_Grain, &
+                        subkind_Tuber, &
+                        subkind_Vegetative, &
+                        modeCycle_CalendarDays, &
+                        modeCycle_GDDays, &
                         LeapYear, &
                         DetermineDayNr, &
                         DetermineDayNr, &
@@ -63,7 +63,6 @@ use ac_global, only:    DaysInMonth, &
                         GetCO2FileFull, &
                         SeasonalSumOfKcPot, &
                         DaysToReachCCwithGivenCGC
-
 use ac_kinds, only: dp, &
                     int8, &
                     int16, &
@@ -76,8 +75,7 @@ use ac_tempprocessing, only: GDDCDCToCDC, &
                         fTnxReference_open, &
                         fTnxReference_write, & 
                         fTnxReference_close,&
-                             CropStressParametersSoilSalinity
-
+                        CropStressParametersSoilSalinity
 use ac_project_input, only: GetNumberSimulationRuns, &
                             ProjectInput
 use ac_utils, only: roundc, &
@@ -89,8 +87,6 @@ implicit none
 
 
 contains
-
-
 
 
 integer(int32) function SumCalendarDaysReferenceTnx(ValGDDays, RefCropDay1,&
@@ -107,7 +103,6 @@ integer(int32) function SumCalendarDaysReferenceTnx(ValGDDays, RefCropDay1,&
     integer(int32) :: i
     integer(int32) :: NrCDays
     real(dp) :: RemainingGDDays, DayGDD
-    
     real(dp) :: TDayMin_loc, TDayMax_loc
     
     TDayMin_loc = TDayMin
@@ -124,35 +119,8 @@ integer(int32) function SumCalendarDaysReferenceTnx(ValGDDays, RefCropDay1,&
             else
                 NrCDays = roundc(ValGDDays/DayGDD, mold=1_int32)
             end if
-        !else if (GetTemperatureFile() == '(External)') then
-        !    RemainingGDDays = ValGDDays
-        !    i = GetCrop_Day1()-GetSimulation_FromDayNr()+1
-        !    TDayMin_loc = real(GetTminRun_i(i),kind=dp)
-        !    TDayMax_loc = real(GetTmaxRun_i(i),kind=dp)
-        !    DayGDD = DegreesDay(Tbase, Tupper, TDayMin_loc, &
-        !                                TDayMax_loc, &
-        !                                GetSimulParam_GDDMethod())
-        !    NrCDays = NrCDays + 1
-        !    RemainingGDDays = RemainingGDDays - DayGDD
-        !
-        !    do while ((RemainingGDDays > 0) &
-        !                   .and. (i < (GetSimulation_ToDayNr()-GetSimulation_FromDayNr()+1)))
-        !          i = i + 1
-        !          TDayMin_loc = real(GetTminRun_i(i),kind=dp)
-        !          TDayMax_loc = real(GetTmaxRun_i(i),kind=dp)
-        ! 
-        !          DayGDD = DegreesDay(Tbase, Tupper, TDayMin_loc, &
-        !                               TDayMax_loc, &
-        !                               GetSimulParam_GDDMethod())
-        !          NrCDays = NrCDays + 1
-        !          RemainingGDDays = RemainingGDDays - DayGDD
-        !    end do
-        !
-        !    if (RemainingGDDays > 0) then
-        !        NrCDays = undef_int
-        !    end if
         else
-            ! open TCropReference.SIM : mean daily Tnx (365 days) from RefCropDay1 onwards
+            ! Get TCropReference: mean daily Tnx (365 days) from RefCropDay1 onwards
             ! determine corresponding calendar days
             RemainingGDDays = ValGDDays
 
@@ -170,11 +138,6 @@ integer(int32) function SumCalendarDaysReferenceTnx(ValGDDays, RefCropDay1,&
                 DayGDD = DegreesDay(Tbase, Tupper, TDayMin_loc, &
                                     TDayMax_loc, &
                                     GetSimulParam_GDDMethod())
-            WRITE(*, '(A, f10.6)') 'The value of RemainingGDDays is:', RemainingGDDays
-            WRITE(*, '(A, I4)') 'The value of StartDayNr is:', StartDayNr
-            WRITE(*, '(A, I4)') 'The value of RefCropDay1 is:', RefCropDay1
-            WRITE(*, '(A, f10.2)') 'TDayMin_loc:', TDayMin_loc
-            WRITE(*, '(A, f10.8)') 'The value of DayGDD is:', DayGDD
                 if (DayGDD > RemainingGDDays) then
                     if (roundc((DayGDD-RemainingGDDays)/RemainingGDDays,mold=1) >= 1) then
                         NrCDays = NrCDays + 1
@@ -182,25 +145,21 @@ integer(int32) function SumCalendarDaysReferenceTnx(ValGDDays, RefCropDay1,&
                 else
                     NrCDays = NrCDays + 1
                 end if
-            WRITE(*, '(A, i4)') 'The value of NrCDays is:', NrCDays
                 RemainingGDDays = RemainingGDDays - DayGDD
             end do
         end if
     end if
     SumCalendarDaysReferenceTnx = NrCDays
-    WRITE(*, *) 'End of SumCalendarDaysReference'
 end function SumCalendarDaysReferenceTnx
 
 
-
-
 subroutine AdjustCalendarDaysReferenceTnx(PlantDayNr, TheCropType, &
-        Tbase, Tupper, TDayMin, TDayMax, &
-        GDDL0, GDDL12, GDDFlor, GDDLengthFlor, GDDL123, &
-        GDDL1234, GDDHImax, GDDCGC, GDDCDC, &
-        CCo, CCx, RefHI, TheDaysToCCini, TheGDDaysToCCini, &
-        ThePlanting, L0, L12, LFlor, LengthFlor, &
-        L123, L1234, LHImax, CGC, CDC, RatedHIdt)
+                    Tbase, Tupper, TDayMin, TDayMax, &
+                    GDDL0, GDDL12, GDDFlor, GDDLengthFlor, GDDL123, &
+                    GDDL1234, GDDHImax, GDDCGC, GDDCDC, &
+                    CCo, CCx, RefHI, TheDaysToCCini, TheGDDaysToCCini, &
+                    ThePlanting, L0, L12, LFlor, LengthFlor, &
+                    L123, L1234, LHImax, CGC, CDC, RatedHIdt)
     integer(int32), intent(in) :: PlantDayNr
     integer(intEnum), intent(in) :: TheCropType
     real(dp), intent(in) :: Tbase
@@ -237,37 +196,47 @@ subroutine AdjustCalendarDaysReferenceTnx(PlantDayNr, TheCropType, &
 
     if (TheDaysToCCini == 0) then
         ! planting/sowing
-        L0 = SumCalendarDaysReferenceTnx(GDDL0, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
-        L12 = SumCalendarDaysReferenceTnx(GDDL12, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+        L0 = SumCalendarDaysReferenceTnx(GDDL0, PlantDayNr, PlantDayNr, &
+            Tbase, Tupper, TDayMin, TDayMax)
+        L12 = SumCalendarDaysReferenceTnx(GDDL12, PlantDayNr, PlantDayNr, &
+            Tbase, Tupper, TDayMin, TDayMax)
     else
         ! regrowth
         if (TheDaysToCCini > 0) then
             ! CCini < CCx
             ExtraGDDays = GDDL12 - GDDL0 - TheGDDaysToCCini
-            ExtraDays = SumCalendarDaysReferenceTnx(ExtraGDDays, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+            ExtraDays = SumCalendarDaysReferenceTnx(ExtraGDDays, PlantDayNr, &
+                PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
             L12 = L0 + TheDaysToCCini + ExtraDays
         end if
     end if
     if (TheCropType /= subkind_Forage) then
-        L123 = SumCalendarDaysReferenceTnx(GDDL123, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
-        L1234 = SumCalendarDaysReferenceTnx(GDDL1234, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+        L123 = SumCalendarDaysReferenceTnx(GDDL123, PlantDayNr, PlantDayNr, &
+            Tbase, Tupper, TDayMin, TDayMax)
+        L1234 = SumCalendarDaysReferenceTnx(GDDL1234, PlantDayNr, PlantDayNr, &
+            Tbase, Tupper, TDayMin, TDayMax)
     end if
 
     select case (TheCropType)
     case (subkind_Grain, subkind_Tuber)
-        LFlor = SumCalendarDaysReferenceTnx(GDDFlor, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+        LFlor = SumCalendarDaysReferenceTnx(GDDFlor, PlantDayNr, PlantDayNr, &
+            Tbase, Tupper, TDayMin, TDayMax)
         if (TheCropType == subkind_Grain) then
-            LengthFlor = SumCalendarDaysReferenceTnx(GDDLengthFlor, PlantDayNr, (PlantDayNr+LFlor), Tbase, Tupper, TDayMin, TDayMax)
+            LengthFlor = SumCalendarDaysReferenceTnx(GDDLengthFlor, PlantDayNr, &
+                (PlantDayNr+LFlor), Tbase, Tupper, TDayMin, TDayMax)
         else
             LengthFlor = 0
         end if
-        LHImax = SumCalendarDaysReferenceTnx(GDDHImax, PlantDayNr, (PlantDayNr+LFlor), Tbase, Tupper, TDayMin, TDayMax)
+        LHImax = SumCalendarDaysReferenceTnx(GDDHImax, PlantDayNr, &
+            (PlantDayNr+LFlor), Tbase, Tupper, TDayMin, TDayMax)
     case (subkind_Vegetative, subkind_Forage)
-        LHImax = SumCalendarDaysReferenceTnx(GDDHImax, PlantDayNr, PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
+        LHImax = SumCalendarDaysReferenceTnx(GDDHImax, PlantDayNr, &
+            PlantDayNr, Tbase, Tupper, TDayMin, TDayMax)
     end select
 
     CGC = (real(GDDL12, kind=dp)/real(L12, kind=dp)) * GDDCGC
-    call GDDCDCToCDC(PlantDayNr, L123, GDDL123, GDDL1234, CCx, GDDCDC, Tbase, Tupper, TDayMin, TDayMax, CDC)
+    call GDDCDCToCDC(PlantDayNr, L123, GDDL123, GDDL1234, CCx, GDDCDC, &
+        Tbase, Tupper, TDayMin, TDayMax, CDC)
     if ((TheCropType == subkind_Grain) .or. (TheCropType == subkind_Tuber)) then
         RatedHIdt = real(RefHI, kind=dp)/real(LHImax, kind=dp)
     end if
@@ -290,15 +259,12 @@ subroutine AdjustCalendarDaysReferenceTnx(PlantDayNr, TheCropType, &
 end subroutine AdjustCalendarDaysReferenceTnx
 
 
-
-
-
 subroutine DailyTnxReferenceFileCoveringCropPeriod(CropFirstDay)
     integer(int32), intent(in) :: CropFirstDay
 
     integer(int32) :: DayNr1
     integer(int32) :: Dayi, Monthi, Yeari, i
-    real(dp) :: Tlow, Thigh
+    real(sp) :: Tlow, Thigh
     character(len=1025) :: TempString
 
     if (FileExists(GetTnxReferenceFileFull())) then
@@ -306,38 +272,41 @@ subroutine DailyTnxReferenceFileCoveringCropPeriod(CropFirstDay)
         call DetermineDate(CropFirstDay, Dayi, Monthi, Yeari)
         call DetermineDayNr(Dayi, Monthi, (1901), DayNr1)
         
-        ! create SIM file and record first day
-
-        call fTnxReference_open(trim(GetPathNameSimul()) // 'TCropReference.SIM','w')
+        if (GetTnxReferenceFile() /= '(External)') then
+            ! create SIM file
+            call fTnxReference_open(trim(GetPathNameSimul()) // 'TCropReference.SIM','w')
+        end if
         
-        !WRITE(*, '(A, i4)') 'DayNr1:', DayNr1
-        !WRITE(*, '(A, f10.2)') 'Tlow:', GetTminTnxReference365DaysRun_i(DayNr1)
-
         i = 0
         do Dayi = DayNr1, 365
             i=i+1
             Tlow = GetTminTnxReference365DaysRun_i(Dayi)
             Thigh = GetTmaxTnxReference365DaysRun_i(Dayi)
-            write(TempString, '(f10.2, f10.2)') Tlow,Thigh
             call SetTminCropReferenceRun_i(i,Tlow)
             call SetTmaxCropReferenceRun_i(i,Thigh)
-            call fTnxReference_write(trim(TempString))
+            if (GetTnxReferenceFile() /= '(External)') then
+                write(TempString, '(f10.2, f10.2)') Tlow,Thigh
+                call fTnxReference_write(trim(TempString))
+            end if
         end do
         do Dayi = 1, (DayNr1-1)
             i=i+1
             Tlow = GetTminTnxReference365DaysRun_i(Dayi)
             Thigh = GetTmaxTnxReference365DaysRun_i(Dayi)
-            write(TempString, '(f10.2, f10.2)') Tlow,Thigh
             call SetTminCropReferenceRun_i(i,Tlow)
             call SetTmaxCropReferenceRun_i(i,Thigh)
-            call fTnxReference_write(trim(TempString))
+            if (GetTnxReferenceFile() /= '(External)') then
+                write(TempString, '(f10.2, f10.2)') Tlow,Thigh
+                call fTnxReference_write(trim(TempString))
+            end if
         end do
         
-        ! Close files
-        call fTnxReference_close()
+        if (GetTnxReferenceFile() /= '(External)') then
+            ! Close files
+            call fTnxReference_close()
+        end if
     end if
 end subroutine DailyTnxReferenceFileCoveringCropPeriod
-
 
 
 real(dp) function CO2ForTnxReferenceYear(TnxReferenceYear)
@@ -358,8 +327,6 @@ real(dp) function CO2ForTnxReferenceYear(TnxReferenceYear)
         end do
         ! from year
         read(fhandle, '(a)', iostat=rc) TempString
-            !WRITE(*, *) 'TempString'
-            !WRITE(*, *) TempString
         call SplitStringInTwoParams(trim(TempString), YearB, CO2b)
         if (roundc(YearB, mold=1) >= TnxReferenceYear) then
             TheCO2 = CO2b
@@ -879,8 +846,6 @@ subroutine ReferenceStressBiomassRelationship(TheDaysToCCini, &
     integer(intEnum), intent(in) :: ThePlanting
     integer(int32), intent(in) :: LHImax
 
-
-
     integer(int32) :: RefCropDay1
     integer(int32) :: Dayi, Monthi, Yeari
     real(dp) :: CO2TnxReferenceYear
@@ -895,70 +860,16 @@ subroutine ReferenceStressBiomassRelationship(TheDaysToCCini, &
     real(dp) :: CDC_loc
     real(dp) :: RatedHIdt_loc
 
-
-
-    WRITE(*, '(I4)') TheDaysToCCini
-    WRITE(*, '(I4)') TheGDDaysToCCini
-    WRITE(*, '(I4)') L0
-    WRITE(*, '(I4)') L12
-    WRITE(*, '(I4)') L123
-    WRITE(*, '(I4)') L1234
-    WRITE(*, '(I4)') LFlor
-    WRITE(*, '(I4)') LengthFlor
-    WRITE(*, '(I4)') GDDL0
-    WRITE(*, '(I4)') GDDL12
-    WRITE(*, '(I4)') GDDL123
-    WRITE(*, '(I4)') GDDL1234
-    WRITE(*, '(I4)') WPyield
-    WRITE(*, '(I4)') RefHI
-    WRITE(*, '(f10.2)') CCo
-    WRITE(*, '(f10.2)') CCx
-    WRITE(*, '(f10.2)') CGC
-    WRITE(*, '(f10.2)') GDDCGC
-    WRITE(*, '(f10.2)') CDC
-    WRITE(*, '(f10.2)') GDDCDC
-    WRITE(*, '(f10.2)') KcTop
-    WRITE(*, '(f10.2)') KcDeclAgeing
-    WRITE(*, '(f10.2)') CCeffectProcent
-    WRITE(*, '(f10.2)') Tbase
-    WRITE(*, '(f10.2)') Tupper
-    WRITE(*, '(f10.2)') TDayMin
-    WRITE(*, '(f10.2)') TDayMax
-    WRITE(*, '(f10.2)') GDtranspLow
-    WRITE(*, '(f10.2)') WPveg
-    WRITE(*, '(f10.2)') RatedHIdt
-    WRITE(*, '(I6)') CropDNr1
-    !logical, intent(in) :: CropDeterm
-    !type(rep_Shapes), intent(in) :: CropSResp
-    WRITE(*, '(I4)') TheCropType
-    WRITE(*, '(I4)') TheModeCycle
-    WRITE(*, '(f10.2)') b0
-    WRITE(*, '(f10.2)') b1
-    WRITE(*, '(f10.2)') b2
-    WRITE(*, '(f10.2)') BM10
-    WRITE(*, '(f10.2)') BM20
-    WRITE(*, '(f10.2)') BM30
-    WRITE(*, '(f10.2)') BM40
-    WRITE(*, '(f10.2)') BM50
-    WRITE(*, '(f10.2)') BM60
-    WRITE(*, '(f10.2)') BM70
-    WRITE(*, '(I4)') GDDFlor
-    WRITE(*, '(I4)') GDDLengthFlor
-    WRITE(*, '(I4)') GDDHImax
-    WRITE(*, '(I4)') ThePlanting
-    WRITE(*, '(I4)') LHImax
-        L0_loc = L0
-        L12_loc = L12
-        LFlor_loc = LFlor
-        LengthFlor_loc = LengthFlor
-        L123_loc = L123
-        L1234_loc = L1234
-        LHImax_loc = LHImax
-        CGC_loc = CGC
-        CDC_loc =  CDC 
-        RatedHIdt_loc = RatedHIdt
-    
-
+    L0_loc = L0
+    L12_loc = L12
+    LFlor_loc = LFlor
+    LengthFlor_loc = LengthFlor
+    L123_loc = L123
+    L1234_loc = L1234
+    LHImax_loc = LHImax
+    CGC_loc = CGC
+    CDC_loc =  CDC 
+    RatedHIdt_loc = RatedHIdt
 
     ! 1. Day 1 of the GrowingCycle
     call DetermineDate(CropDNr1, Dayi, Monthi, Yeari)

--- a/src/preparefertilitysalinity.f90
+++ b/src/preparefertilitysalinity.f90
@@ -1,86 +1,86 @@
 module ac_preparefertilitysalinity
 
-use ac_global, only:    DaysInMonth, & 
-                        DetermineDate,&
-                        HarvestIndexGrowthCoefficient, &
-                        DegreesDay, &
-                        GetTnxReferenceYear,&
-                        GetTminCropReferenceRun, &
-                        SetTminCropReferenceRun, &
-                        GetTminCropReferenceRun_i, &
-                        SetTminCropReferenceRun_i, &
-                        GetTmaxCropReferenceRun, &
-                        SetTmaxCropReferenceRun, &
-                        GetTmaxCropReferenceRun_i, &
-                        SetTmaxCropReferenceRun_i, &
-                        GetTminTnxReference365DaysRun,&
-                        GetTmaxTnxReference365DaysRun,&
-                        GetTminTnxReference365DaysRun_i,&
-                        GetTmaxTnxReference365DaysRun_i,&
-                        SetTminTnxReference365DaysRun,&
-                        SetTmaxTnxReference365DaysRun,&
-                        SetTminTnxReference365DaysRun_i,&
-                        SetTmaxTnxReference365DaysRun_i,&
-                        FileExists, &
-                        undef_double, &
-                        undef_int, &
-                        CO2ref,&
-                        rep_DayEventDbl,&
-                        rep_Shapes,&
-                        rep_EffectStress,&
-                        Subkind_Forage, &
-                        subkind_Grain,  &
-                        subkind_Grain, &
-                        subkind_Tuber, &
-                        subkind_Vegetative, &
-                        modeCycle_CalendarDays, &
-                        modeCycle_GDDays, &
-                        LeapYear, &
-                        DetermineDayNr, &
-                        DetermineDayNr, &
-                        SplitStringInTwoParams, &
-                        SetSimulation_DelayedDays, &
-                        GetDaySwitchToLinear, &
-                        CropStressParametersSoilFertility, &
-                        TimeToMaxCanopySF, &
-                        GetPathNameSimul, &
-                        GetTemperatureRecord_ToY, &
-                        GetTemperatureRecord_FromY, &
-                        GetTemperatureRecord_ToM, &
-                        GetTemperatureRecord_FromM, &
-                        GetTemperatureRecord_ToDayNr, &
-                        GetTemperatureRecord_FromDayNr, &
-                        GetTemperatureRecord_DataType, &
-                        GetTemperatureFile, &
-                        GetTemperatureFilefull, &
-                        datatype_daily, &
-                        datatype_decadely, &
-                        SetTnxReferenceFile, &
-                        GetTnxReferenceFile, &
-                        SetTnxReferenceFileFull, &
-                        GetTnxReferenceFileFull, &
-                        GetSimulParam_GDDMethod, &
-                        GetCO2FileFull, &
-                        SeasonalSumOfKcPot, &
-                        DaysToReachCCwithGivenCGC
+use ac_global, only: CO2ref,& 
+                     CropStressParametersSoilFertility, & 
+                     datatype_daily, & 
+                     datatype_decadely, & 
+                     DaysInMonth, &  
+                     DaysToReachCCwithGivenCGC, & 
+                     DegreesDay, & 
+                     DetermineDate,& 
+                     DetermineDayNr, & 
+                     DetermineDayNr, & 
+                     FileExists, & 
+                     GetCO2FileFull, & 
+                     GetDaySwitchToLinear, & 
+                     GetPathNameSimul, & 
+                     GetSimulParam_GDDMethod, & 
+                     GetTemperatureFile, & 
+                     GetTemperatureFilefull, & 
+                     GetTemperatureRecord_DataType, & 
+                     GetTemperatureRecord_FromDayNr, & 
+                     GetTemperatureRecord_FromM, & 
+                     GetTemperatureRecord_FromY, & 
+                     GetTemperatureRecord_ToDayNr, & 
+                     GetTemperatureRecord_ToM, & 
+                     GetTemperatureRecord_ToY, & 
+                     GetTmaxCropReferenceRun, & 
+                     GetTmaxCropReferenceRun_i, & 
+                     GetTmaxTnxReference365DaysRun,& 
+                     GetTmaxTnxReference365DaysRun_i,& 
+                     GetTminCropReferenceRun, & 
+                     GetTminCropReferenceRun_i, & 
+                     GetTminTnxReference365DaysRun,& 
+                     GetTminTnxReference365DaysRun_i,& 
+                     GetTnxReferenceFile, & 
+                     GetTnxReferenceFileFull, & 
+                     GetTnxReferenceYear,& 
+                     HarvestIndexGrowthCoefficient, & 
+                     LeapYear, & 
+                     modeCycle_CalendarDays, & 
+                     modeCycle_GDDays, & 
+                     rep_DayEventDbl,& 
+                     rep_EffectStress,& 
+                     rep_Shapes,& 
+                     SeasonalSumOfKcPot, & 
+                     SetSimulation_DelayedDays, & 
+                     SetTmaxCropReferenceRun, & 
+                     SetTmaxCropReferenceRun_i, & 
+                     SetTmaxTnxReference365DaysRun,& 
+                     SetTmaxTnxReference365DaysRun_i,& 
+                     SetTminCropReferenceRun, & 
+                     SetTminCropReferenceRun_i, & 
+                     SetTminTnxReference365DaysRun,& 
+                     SetTminTnxReference365DaysRun_i,& 
+                     SetTnxReferenceFile, & 
+                     SetTnxReferenceFileFull, & 
+                     SplitStringInTwoParams, & 
+                     Subkind_Forage, & 
+                     subkind_Grain,  & 
+                     subkind_Grain, & 
+                     subkind_Tuber, & 
+                     subkind_Vegetative, & 
+                     TimeToMaxCanopySF, & 
+                     undef_double, & 
+                     undef_int
 use ac_kinds, only: dp, &
                     int8, &
                     int16, &
                     int32, &
                     intEnum, &
                     sp
-use ac_tempprocessing, only: GDDCDCToCDC, &
-                        GrowingDegreeDays, &
-                        Bnormalized, &
+use ac_tempprocessing, only: Bnormalized, &
+                        CropStressParametersSoilSalinity, &
                         fTnxReference_open, &
                         fTnxReference_write, & 
                         fTnxReference_close,&
-                        CropStressParametersSoilSalinity
+                        GDDCDCToCDC, &
+                        GrowingDegreeDays
 use ac_project_input, only: GetNumberSimulationRuns, &
                             ProjectInput
-use ac_utils, only: roundc, &
-                    GetReleaseDate, &
+use ac_utils, only: GetReleaseDate, &
                     GetVersionString, &
+                    roundc, &
                     trunc
 use iso_fortran_env, only: iostat_end
 implicit none

--- a/src/run.f90
+++ b/src/run.f90
@@ -5,6 +5,9 @@ use ac_climprocessing, only:    GetDecadeEToDataset, &
                                 GetMonthlyEToDataset, &
                                 GetMonthlyRainDataset
 use ac_global, only:    AdjustSizeCompartments, &
+                        GetCrop_DaysToHIo, &
+                        GetCrop_GDDaysToHIo, &
+                        GetOut8Irri, &
                         CompartmentIndividual, &
                         datatype_daily, &
                         datatype_decadely, &
@@ -406,16 +409,34 @@ use ac_rootunit, only:  AdjustedRootingDepth
 use ac_simul,    only:  Budget_module, &
                         determinepotentialbiomass, &
                         determinebiomassandyield
-use ac_tempprocessing, only:    CCxSaltStressRelationship, &
-                                GetDecadeTemperatureDataSet, &
+use ac_tempprocessing, only:    GetDecadeTemperatureDataSet, &
                                 GetMonthlyTemperaturedataset, &
                                 GrowingDegreeDays, &
                                 LoadSimulationRunProject, &
-                                StressBiomassRelationship, &
-                                temperaturefilecoveringcropperiod
+                                temperaturefilecoveringcropperiod, &
+                                GetTminDataSet, & 
+                                GetTmaxDataSet, &
+                                GetTminDataSet_i, & 
+                                GetTmaxDataSet_i, &
+                                GetTminDataSet_DayNr, &
+                                GetTminDataSet_Param, &
+                                GetTmaxDataSet_DayNr, &
+                                GetTmaxDataSet_Param, &
+                                SetTminDataSet, & 
+                                SetTmaxDataSet, &
+                                SetTminDataSet_i, & 
+                                SetTmaxDataSet_i, &
+                                SetTminDataSet_DayNr, &
+                                SetTminDataSet_Param, &
+                                SetTmaxDataSet_DayNr, &
+                                SetTmaxDataSet_Param
+use ac_preparefertilitysalinity, only:  ReferenceCCxSaltStressRelationship, &
+                                ReferenceStressBiomassRelationship
 use ac_utils, only: assert, &
                     GetAquaCropDescriptionWithTimeStamp, &
-                    roundc
+                    roundc, &
+                    write_file, &
+                    open_file
 use iso_fortran_env, only: iostat_end
 implicit none
 
@@ -515,7 +536,10 @@ integer :: fObs ! file handle
 integer :: fObs_iostat ! IO status
 integer :: fHarvest  ! file handle
 integer :: fHarvest_iostat  ! IO status
+integer :: fIrrInfo  ! file handle
+integer :: fIrrInfo_iostat  ! IO status
 character(len=:), allocatable :: fHarvest_filename  ! file name
+character(len=:), allocatable :: fIrrInfo_filename  ! file name
 
 type(rep_GwTable) :: GwTable
 type(rep_DayEventDbl), dimension(31) :: EToDataSet
@@ -532,7 +556,7 @@ integer(int32) :: DayNri
 integer(int32) :: IrriInterval
 integer(int32) :: Tadj, GDDTadj
 integer(int32) :: DayLastCut,NrCut,SumInterval
-integer(int8)  :: PreviousStressLevel, StressSFadjNEW
+integer(int32)  :: PreviousStressLevel, StressSFadjNEW
 
 real(dp) :: Bin
 real(dp) :: Bout
@@ -572,66 +596,11 @@ character(len=:), allocatable :: fEval_filename
 logical :: WaterTableInProfile, StartMode, NoMoreCrop
 logical :: GlobalIrriECw ! for versions before 3.2 where EC of
                          ! irrigation water was not yet recorded
-
+! Version 7.2
+integer(int32) :: LastIrriDAP
 
 
 contains
-
-
-subroutine open_file(fhandle, filename, mode, iostat)
-    !! Opens a file in the given mode.
-    integer, intent(out) :: fhandle
-        !! file handle to be used for the open file
-    character(len=*), intent(in) :: filename
-        !! name of the file to assign the file handle to
-    character, intent(in) :: mode
-        !! open the file for reading ('r'), writing ('w') or appending ('a')
-    integer, intent(out) :: iostat
-        !! IO status returned by open()
-
-    logical :: file_exists
-
-    inquire(file=filename, exist=file_exists)
-
-    if (mode == 'r') then
-        open(newunit=fhandle, file=trim(filename), status='old', &
-             action='read', iostat=iostat)
-    elseif (mode == 'a') then
-        if (file_exists) then
-            open(newunit=fhandle, file=trim(filename), status='old', &
-                 position='append', action='write', iostat=iostat)
-        else
-            open(newunit=fhandle, file=trim(filename), status='new', &
-                 action='write', iostat=iostat)
-        end if
-    elseif (mode == 'w') then
-        open(newunit=fhandle, file=trim(filename), status='replace', &
-             action='write', iostat=iostat)
-    end if
-end subroutine open_file
-
-
-subroutine write_file(fhandle, line, advance, iostat)
-    !! Writes one line to a file.
-    integer, intent(in) :: fhandle
-        !! file handle of an already-opened file
-    character(len=*), intent(in) :: line
-        !! line to write to the file
-    logical, intent(in) :: advance
-        !! whether or not to append a newline character
-    integer, intent(out) :: iostat
-        !! IO status returned by write()
-
-    character(len=:), allocatable :: advance_str
-
-    if (advance) then
-        advance_str = 'yes'
-    else
-        advance_str = 'no'
-    end if
-
-    write(fhandle, '(a)', advance=advance_str, iostat=iostat) line
-end subroutine write_file
 
 
 function read_file(fhandle, iostat) result(line)
@@ -986,6 +955,66 @@ end subroutine fObs_close
 subroutine fObs_rewind()
     rewind(fObs)
 end subroutine fObs_rewind
+
+
+! fIrrInfo
+
+function GetfIrrInfo_filename() result(str)
+    !! Getter for the "fIrrInfo_filename" global variable.
+    character(len=:), allocatable :: str
+
+    str = fIrrInfo_filename
+end function GetfIrrInfo_filename
+
+
+subroutine SetfIrrInfo_filename(str)
+    !! Setter for the "fIrrInfo_filename" global variable.
+    character(len=*), intent(in) :: str
+
+    fIrrInfo_filename = str
+end subroutine SetfIrrInfo_filename
+
+
+subroutine fIrrInfo_open(filename, mode)
+    !! Opens the given file, assigning it to the 'fIrrInfo' file handle.
+    character(len=*), intent(in) :: filename
+        !! name of the file to assign the file handle to
+    character, intent(in) :: mode
+        !! open the file for reading ('r'), writing ('w') or appending ('a')
+
+    call open_file(fIrrInfo, filename, mode, fIrrInfo_iostat)
+end subroutine fIrrInfo_open
+
+
+subroutine fIrrInfo_write(line, advance_in)
+    !! Writes the given line to the fIrrInfo file.
+    character(len=*), intent(in) :: line
+        !! line to write
+    logical, intent(in), optional :: advance_in
+        !! whether or not to append a newline character
+
+    logical :: advance
+
+    if (present(advance_in)) then
+        advance = advance_in
+    else
+        advance = .true.
+    end if
+    call write_file(fIrrInfo, line, advance, fIrrInfo_iostat)
+
+    if (advance) then
+        ! For some reason (a compiler bug?) we need to explicitly flush
+        ! the buffer here. Otherwise, with GNU Fortran v10.2.1 and DEBUG=0,
+        ! the last line of test_defaultPROharvests.OUT in the IrrInfo test
+        ! does not get written. This does not occur when either DEBUG=1 is
+        ! applied or when using GNU Fortran v6.4.0.
+        call flush(fIrrInfo)
+    end if
+end subroutine fIrrInfo_write
+
+subroutine fIrrInfo_close()
+    close(fIrrInfo)
+end subroutine fIrrInfo_close
 
 
 ! fHarvest
@@ -2182,136 +2211,6 @@ subroutine SetTransfer_Bmobilized(Bmobilized)
 end subroutine SetTransfer_Bmobilized
 
 
-!TminDatSet
-
-function GetTminDataSet() result(TminDataSet_out)
-    !! Getter for the "TminDataSet" global variable.
-    type(rep_DayEventDbl), dimension(31) :: TminDataSet_out
-
-    TminDataSet_out = TminDataSet
-end function GetTminDataSet
-
-
-function GetTminDataSet_i(i) result(TminDataSet_i)
-    !! Getter for individual elements of the "TminDataSet" global variable.
-    integer(int32), intent(in) :: i
-    type(rep_DayEventDbl) :: TminDataSet_i
-
-    TminDataSet_i = TminDataSet(i)
-end function GetTminDataSet_i
-
-
-integer(int32) function GetTminDataSet_DayNr(i)
-    integer(int32), intent(in) :: i
-
-    GetTminDataSet_DayNr = TminDataSet(i)%DayNr
-end function GetTminDataSet_DayNr
-
-
-real(dp) function GetTminDataSet_Param(i)
-    integer(int32), intent(in) :: i
-
-    GetTminDataSet_Param = TminDataSet(i)%Param
-end function GetTminDataSet_Param
-
-
-subroutine SetTminDataSet(TminDataSet_in)
-    !! Setter for the "TminDatSet" global variable.
-    type(rep_DayEventDbl), dimension(31), intent(in) :: TminDataSet_in
-
-    TminDataSet = TminDataSet_in
-end subroutine SetTminDataSet
-
-
-subroutine SetTminDataSet_i(i, TminDataSet_i)
-    !! Setter for individual element for the "TminDataSet" global variable.
-    integer(int32), intent(in) :: i
-    type(rep_DayEventDbl), intent(in) :: TminDataSet_i
-
-    TminDataSet(i) = TminDataSet_i
-end subroutine SetTminDataSet_i
-
-
-subroutine SetTminDataSet_DayNr(i, DayNr_in)
-    integer(int32), intent(in) :: i
-    integer(int32), intent(in) :: DayNr_in
-
-    TminDataSet(i)%DayNr = DayNr_in
-end subroutine SetTminDataSet_DayNr
-
-
-subroutine SetTminDataSet_Param(i, Param_in)
-    integer(int32), intent(in) :: i
-    real(dp), intent(in) :: Param_in
-
-    TminDataSet(i)%Param = Param_in
-end subroutine SetTminDataSet_Param
-
-! TmaxDataSet
-
-function GetTmaxDataSet() result(TmaxDataSet_out)
-    !! Getter for the "TmaxDataSet" global variable.
-    type(rep_DayEventDbl), dimension(31) :: TmaxDataSet_out
-
-    TmaxDataSet_out = TmaxDataSet
-end function GetTmaxDataSet
-
-
-function GetTmaxDataSet_i(i) result(TmaxDataSet_i)
-    !! Getter for individual elements of the "TmaxDataSet" global variable.
-    integer(int32), intent(in) :: i
-    type(rep_DayEventDbl) :: TmaxDataSet_i
-
-    TmaxDataSet_i = TmaxDataSet(i)
-end function GetTmaxDataSet_i
-
-
-integer(int32) function GetTmaxDataSet_DayNr(i)
-    integer(int32), intent(in) :: i
-
-    GetTmaxDataSet_DayNr = TmaxDataSet(i)%DayNr
-end function GetTmaxDataSet_DayNr
-
-
-real(dp) function GetTmaxDataSet_Param(i)
-    integer(int32), intent(in) :: i
-
-    GetTmaxDataSet_Param = TmaxDataSet(i)%Param
-end function GetTmaxDataSet_Param
-
-
-subroutine SetTmaxDataSet(TmaxDataSet_in)
-    !! Setter for the "TmaxDatSet" global variable.
-    type(rep_DayEventDbl), dimension(31), intent(in) :: TmaxDataSet_in
-
-    TmaxDataSet = TmaxDataSet_in
-end subroutine SetTmaxDataSet
-
-
-subroutine SetTmaxDataSet_i(i, TmaxDataSet_i)
-    !! Setter for individual element for the "TmaxDataSet" global variable.
-    integer(int32), intent(in) :: i
-    type(rep_DayEventDbl), intent(in) :: TmaxDataSet_i
-
-    TmaxDataSet(i) = TmaxDataSet_i
-end subroutine SetTmaxDataSet_i
-
-
-subroutine SetTmaxDataSet_DayNr(i, DayNr_in)
-    integer(int32), intent(in) :: i
-    integer(int32), intent(in) :: DayNr_in
-
-    TmaxDataSet(i)%DayNr = DayNr_in
-end subroutine SetTmaxDataSet_DayNr
-
-
-subroutine SetTmaxDataSet_Param(i, Param_in)
-    integer(int32), intent(in) :: i
-    real(dp), intent(in) :: Param_in
-
-    TmaxDataSet(i)%Param = Param_in
-end subroutine SetTmaxDataSet_Param
-
 
 integer(int32) function GetDayNri()
 
@@ -2622,7 +2521,7 @@ subroutine SetPreviousStressLevel(PreviousStressLevel_in)
 end subroutine SetPreviousStressLevel
 
 
-integer(int8) function GetStressSFadjNEW()
+integer(int32) function GetStressSFadjNEW()
     !! Getter for the "StressSFadjNEW" global variable.
 
     GetStressSFadjNEW = int(StressSFadjNEW, kind=int32)
@@ -2633,7 +2532,7 @@ subroutine SetStressSFadjNEW(StressSFadjNEW_in)
     !! Setter for the "StressSFadjNEW" global variable.
     integer(int32), intent(in) :: StressSFadjNEW_in
 
-    StressSFadjNEW = int(StressSFadjNEW_in, kind=int8)
+    StressSFadjNEW = int(StressSFadjNEW_in, kind=int32)
 end subroutine SetStressSFadjNEW
 
 
@@ -3402,6 +3301,21 @@ subroutine SetPreviousDayNr(PreviousDayNr_in)
 end subroutine SetPreviousDayNr
 
 
+integer(int32) function GetLastIrriDAP()
+    !! Getter for the "LastIrriDAP" global variable.
+
+    GetLastIrriDAP = LastIrriDAP
+end function GetLastIrriDAP
+
+
+subroutine SetLastIrriDAP(LastIrriDAP_in)
+    !! Setter for the "LastIrriDAP" global variable.
+    integer(int32), intent(in) :: LastIrriDAP_in
+
+    LastIrriDAP = LastIrriDAP_in
+end subroutine SetLastIrriDAP
+
+
 logical function GetNoYear()
     !! Getter for the NoYear global variable
 
@@ -3976,7 +3890,8 @@ subroutine RelationshipsForFertilityAndSaltStress()
 
     ! 1.a Soil fertility (Coeffb0,Coeffb1,Coeffb2 : Biomass-Soil Fertility stress)
     if (GetCrop_StressResponse_Calibrated()) then
-        call StressBiomassRelationship(GetCrop_DaysToCCini(), GetCrop_GDDaysToCCini(), &
+        call ReferenceStressBiomassRelationship(GetCrop_DaysToCCini(), &
+                                  GetCrop_GDDaysToCCini(), &
                                   GetCrop_DaysToGermination(), &
                                   GetCrop_DaysToFullCanopy(), &
                                   GetCrop_DaysToSenescence(), &
@@ -3996,14 +3911,19 @@ subroutine RelationshipsForFertilityAndSaltStress()
                                   GetCrop_Tbase(), &
                                   GetCrop_Tupper(), GetSimulParam_Tmin(), &
                                   GetSimulParam_Tmax(), GetCrop_GDtranspLow(), &
-                                  GetCrop_WP(), GetCrop_dHIdt(), GetCO2i(), &
+                                  GetCrop_WP(), GetCrop_dHIdt(), &
                                   GetCrop_Day1(), GetCrop_DeterminancyLinked(), &
                                   GetCrop_StressResponse(),GetCrop_subkind(), &
                                   GetCrop_ModeCycle(), Coeffb0_temp, Coeffb1_temp, &
-                                  Coeffb2_temp, X10, X20, X30, X40, X50, X60, X70)
+                                  Coeffb2_temp, X10, X20, X30, X40, X50, X60, X70, &
+                                  GetCrop_GDDaysToFlowering(), GetCrop_GDDLengthFlowering(), &
+                                  GetCrop_GDDaysToHIo(), GetCrop_Planting(), GetCrop_DaysToHIo())
         call SetCoeffb0(Coeffb0_temp)
         call SetCoeffb1(Coeffb1_temp)
         call SetCoeffb2(Coeffb2_temp)
+        WRITE(*, '(A, f10.2)') 'The value of Coeffb0_temp is:', Coeffb0_temp
+        WRITE(*, '(A, f10.2)') 'The value of Coeffb0_temp is:', Coeffb1_temp
+        WRITE(*, '(A, f10.2)') 'The value of Coeffb0_temp is:', Coeffb2_temp
     else
         call SetCoeffb0(real(undef_int, kind=dp))
         call SetCoeffb1(real(undef_int, kind=dp))
@@ -4037,7 +3957,7 @@ subroutine RelationshipsForFertilityAndSaltStress()
 
     ! 2. soil salinity (Coeffb0Salt,Coeffb1Salt,Coeffb2Salt : CCx/KsSto - Salt stress)
     if (GetSimulation_SalinityConsidered() .eqv. .true.) then
-        call CCxSaltStressRelationship(GetCrop_DaysToCCini(), &
+        call ReferenceCCxSaltStressRelationship(GetCrop_DaysToCCini(), &
                                   GetCrop_GDDaysToCCini(), &
                                   GetCrop_DaysToGermination(), &
                                   GetCrop_DaysToFullCanopy(), &
@@ -4060,12 +3980,13 @@ subroutine RelationshipsForFertilityAndSaltStress()
                                   GetCrop_Tbase(), GetCrop_Tupper(), &
                                   GetSimulParam_Tmin(), GetSimulParam_Tmax(), &
                                   GetCrop_GDtranspLow(), GetCrop_WP(), &
-                                  GetCrop_dHIdt(), GetCO2i(), GetCrop_Day1(), &
+                                  GetCrop_dHIdt(), GetCrop_Day1(), &
                                   GetCrop_DeterminancyLinked(), &
                                   GetCrop_subkind(), GetCrop_ModeCycle(), &
                                   GetCrop_CCsaltDistortion(),Coeffb0Salt_temp, &
                                   Coeffb1Salt_temp, Coeffb2Salt_temp, X10, X20, X30, &
-                                  X40, X50, X60, X70, X80, X90)
+                                  X40, X50, X60, X70, X80, X90, &
+                                  GetCrop_GDDaysToHIo(), GetCrop_Planting(), GetCrop_DaysToHIo())
         call SetCoeffb0Salt(Coeffb0Salt_temp)
         call SetCoeffb1Salt(Coeffb1Salt_temp)
         call SetCoeffb2Salt(Coeffb2Salt_temp)
@@ -4548,6 +4469,24 @@ subroutine OpenIrrigationFile()
 end subroutine OpenIrrigationFile
 
 
+subroutine WriteTitleIrriInfo(TheProjectType, TheNrRun)
+    integer(intEnum), intent(in) :: TheProjectType
+    integer(int8), intent(in) :: TheNrRun
+
+    character(len=1024) :: tempstring
+
+    ! A. Run number
+    call fIrrInfo_write('')
+    if (TheProjectType == typeproject_TypePRM) then
+        write(tempstring, '(i4)') TheNrRun
+        call fIrrInfo_write('   Run:' // trim(tempstring))
+    end if
+
+    ! B. Title
+    call fIrrInfo_write('   Day Month  Year   DAP Stage    Irri  IrrInt')
+    call fIrrInfo_write('                                    mm    days')
+end subroutine WriteTitleIrriInfo
+
 
 subroutine WriteTitlePart1MultResults(TheProjectType, TheNrRun)
     integer(intEnum), intent(in) :: TheProjectType
@@ -4766,7 +4705,7 @@ subroutine InitializeSimulationRunPart1()
     real(dp) :: fWeed, fi
     integer(int8) :: Cweed
     integer(int32) :: Day1, Month1, Year1
-    integer(int8) :: FertStress
+    integer(int32) :: FertStress
     type(rep_GwTable) :: GwTable_temp
     integer(int8) :: RedCGC_temp, RedCCX_temp, RCadj_temp
     type(rep_EffectStress) :: EffectStress_temp
@@ -4870,7 +4809,7 @@ subroutine InitializeSimulationRunPart1()
 
     ! No soil fertility stress
     if (GetManagement_FertilityStress() <= 0) then
-        call SetManagement_FertilityStress(0_int8)
+        call SetManagement_FertilityStress(0_int32)
     end if
 
     ! Reset soil fertility parameters to selected value in management
@@ -4895,7 +4834,7 @@ subroutine InitializeSimulationRunPart1()
     call SetStressSFadjNEW(int(GetManagement_FertilityStress(),kind=int32))
     ! soil fertility and GDDays
     if (GetCrop_ModeCycle() == modeCycle_GDDays) then
-        if (GetManagement_FertilityStress() /= 0_int8) then
+        if (GetManagement_FertilityStress() /= 0_int32) then
             call SetCrop_GDDaysToFullCanopySF(GrowingDegreeDays(&
                   GetCrop_DaysToFullCanopySF(), GetCrop_Day1(), &
                   GetCrop_Tbase(), GetCrop_Tupper(), GetSimulParam_Tmin(),&
@@ -4916,7 +4855,7 @@ subroutine InitializeSimulationRunPart1()
             GetCrop_KcTop(), GetCrop_KcDecline(), real(GetCrop_CCEffectEvapLate(),kind=dp), &
             GetCrop_Tbase(), GetCrop_Tupper(), GetSimulParam_Tmin(), &
             GetSimulParam_Tmax(), GetCrop_GDtranspLow(), GetCO2i(), &
-            GetCrop_ModeCycle()))
+            GetCrop_ModeCycle(), .true.))
     call SetSumKcTopStress( GetSumKcTop() * GetFracBiomassPotSF())
     call SetSumKci(0._dp)
 
@@ -4938,7 +4877,7 @@ subroutine InitializeSimulationRunPart1()
               GetCrop_CCx(), GetManagement_WeedShape()))
         call SetCCxCropWeedsNoSFstress( roundc(((100._dp*GetCrop_CCx() &
                   * GetfWeedNoS()) + 0.49),mold=1)/100._dp) ! reference for plot with weed
-        if (GetManagement_FertilityStress() > 0_int8) then
+        if (GetManagement_FertilityStress() > 0_int32) then
             fWeed = 1._dp
             if ((fi > 0._dp) .and. (GetCrop_subkind() == subkind_Forage)) then
                 Cweed = 1_int8
@@ -5066,6 +5005,7 @@ subroutine InitializeSimulationRunPart2()
     call SetGlobalIrriECw(.true.) ! In Versions < 3.2 - Irrigation water
                                   ! quality is not yet recorded on file
     call OpenIrrigationFile()
+    call SetLastIrriDAP(0_int32)
 
     ! 12. Adjusted time when starting as regrowth
     if (GetCrop_DaysToCCini() /= 0) then
@@ -5577,6 +5517,25 @@ subroutine OpenOutputDaily(TheProjectType)
 end subroutine OpenOutputDaily
 
 
+subroutine OpenOutputIrrInfo(TheProjectType)
+    integer(intEnum), intent(in) :: TheProjectType
+
+    character(len=:), allocatable :: totalname
+    character(len=1025) :: tempstring
+
+    select case (TheProjectType)
+    case(typeproject_TypePRO)
+        totalname = GetPathNameOutp() // GetOutputName() // 'PROirrInfo.OUT'
+    case(typeproject_TypePRM)
+        totalname = GetPathNameOutp() // GetOutputName() // 'PRMirrInfo.OUT'
+    end select
+    call SetfIrrInfo_filename(totalname)
+    call fIrrInfo_open(GetfIrrInfo_filename(), 'w')
+    write(tempstring, '(a)') GetAquaCropDescriptionWithTimeStamp()
+    call fIrrInfo_write(trim(tempstring))
+end subroutine OpenOutputIrrInfo
+
+
 subroutine OpenPart1MultResults(TheProjectType)
     integer(intEnum), intent(in) :: TheProjectType
 
@@ -6053,6 +6012,9 @@ subroutine InitializeSimulation(TheProjectFileStr, TheProjectType)
     if (GetOutDaily()) then
         call OpenOutputDaily(TheProjectType)  ! Open Daily results .OUT
     end if
+    if (GetOut8Irri()) then
+        call OpenOutputIrrInfo(TheProjectType)  ! Open Irrigation info results .OUT
+    end if
     if (GetPart1Mult()) then
         call OpenPart1MultResults(TheProjectType) ! Open Multiple harvests in season .OUT
     end if
@@ -6064,6 +6026,9 @@ subroutine FinalizeSimulation()
     call fRun_close() ! Close Run.out
     if (GetOutDaily()) then
         call fDaily_close()  ! Close Daily.OUT
+    end if
+    if (GetOut8Irri()) then
+        call fIrrInfo_close()  ! Close Irrigation info results .OUT
     end if
     if (GetPart1Mult()) then
         call fHarvest_close()  ! Close Multiple harvests in season
@@ -6692,6 +6657,10 @@ subroutine InitializeRunPart2(NrRun, TheProjectType)
         call WriteTitleDailyResults(TheProjectType, NrRun)
     end if
 
+    if (GetOut8Irri()) then
+        call WriteTitleIrriInfo(TheProjectType, NrRun)
+    end if
+
     if (GetPart1Mult()) then
         call WriteTitlePart1MultResults(TheProjectType, NrRun)
     end if
@@ -6773,7 +6742,7 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
     real(dp) :: ECiAqua_temp, TactWeedInfested_temp,&
                 Bin_temp, Bout_temp
     integer(int32) :: TargetTimeVal, TargetDepthVal
-    integer(int8) :: PreviousStressLevel_temp, StressSFadjNEW_temp
+    integer(int32) :: PreviousStressLevel_temp, StressSFadjNEW_temp
     real(dp) :: CCxWitheredTpotNoS_temp, &
                 StressLeaf_temp, StressSenescence_temp, TimeSenescence_temp, &
                 SumKcTopStress_temp, SumKci_temp, WeedRCi_temp, &
@@ -7051,7 +7020,7 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
         call DetermineRootZoneWC(GetRootingDepth(), SWCtopSoilConsidered_temp)
         call SetSimulation_SWCtopSoilConsidered(SWCtopSoilConsidered_temp)
         ! temperature stress affecting crop transpiration
-        if (GetCCiActual() <= 0.0000001_dp) then
+        if (GetCCiActual() <= 0.000001_dp) then
              KsTr = 1._dp
         else
              KsTr = KsTemperature(0._dp, GetCrop_GDtranspLow(), GetGDDayi())
@@ -7327,6 +7296,9 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
         call WriteDailyResults((GetDayNri() - GetSimulation_DelayedDays() &
                                 - GetCrop_Day1()+1), WPi)
     end if
+    if (GetOut8Irri()) then
+        call WriteIrrInfo()
+    end if
     if (GetPart2Eval() .and. (GetObservationsFile() /= '(None)')) then
         call WriteEvaluationData((GetDayNri()-GetSimulation_DelayedDays()-GetCrop_Day1()+1))
     end if
@@ -7534,7 +7506,7 @@ subroutine WriteDailyResults(DAP, WPi)
         end if
 
         ! 4. Air temperature stress
-        if (GetCCiActual() <= 0.0000001_dp) then
+        if (GetCCiActual() <= 0.000001_dp) then
             KsTr = 1._dp
         else
             KsTr = KsTemperature(0._dp, GetCrop_GDtranspLow(), GetGDDayi())
@@ -7547,7 +7519,7 @@ subroutine WriteDailyResults(DAP, WPi)
         end if
 
         ! 5. Relative cover of weeds
-        if (GetCCiActual() <= 0.0000001_dp) then
+        if (GetCCiActual() <= 0.000001_dp) then
             StrW = undef_int
         else
             StrW = roundc(GetWeedRCi(), mold=1)
@@ -7768,6 +7740,67 @@ subroutine WriteDailyResults(DAP, WPi)
 end subroutine WriteDailyResults
 
 
+subroutine WriteIrrInfo()
+
+    integer(int32) :: i, Di, Mi, Yi
+    integer(int32) :: DAPi
+    logical        :: IrriON
+    real(dp)       :: IRRmm
+    character(len=1025) :: TempString
+
+    call DetermineDate(GetDayNri(), Di, Mi, Yi)
+    if (GetClimRecord_FromY() == 1901) then
+        Yi = Yi - 1901 + 1
+    end if
+    if ((GetDayNri() < GetCrop_Day1()) .or. &
+        (GetDayNri() > GetCrop_DayN())) then ! before and after growing period
+        write(TempString, '(5i6, i5, f8.1, i6)') &
+           Di, Mi, Yi, undef_int, undef_int, &
+           GetIrrigation(), undef_int
+        call fIrrInfo_write(trim(TempString))
+    else ! during growing period AND irrigation event or last day
+        if ((GetDayNri() == GetCrop_DayN()) .or. & 
+            ((GetIrrigation() > 0._dp) .and. (GetIrriMode() /= IrriMode_Inet))) then ! last day
+            if ((GetIrrigation() <= 0.0001) .and. (GetDayNri() == GetCrop_DayN())) then ! no irrigation on last day
+                IrriON = .false.
+            else
+                IrriON = .true.
+            end if
+            DAPi = (GetDayNri() - GetCrop_Day1() + 1)
+            do i = (GetLastIrriDAP()+1), (DAPi)
+                call DetermineDate((GetDayNri()-(DAPi-GetLastIrriDAP())+(i-GetLastIrriDAP())), Di, Mi, Yi)
+                if (GetClimRecord_FromY() == 1901) then
+                    Yi = Yi - 1901 + 1
+                end if
+                if (i == DAPi) then
+                    IRRmm = GetIrrigation()
+                else
+                    IRRmm = 0._dp
+                end if
+                if (GetIrriMode() == IrriMode_Inet) then ! for last day of growing period
+                    IRRmm = undef_int
+                    IrriON = .false.
+                end if
+                if (IrriON .eqv. .true.) then
+                    write(TempString, '(5i6, i5, f8.1, i6)') &
+                    Di, Mi, Yi, i, undef_int, &
+                    IRRmm, (DAPi - GetLastIrriDAP())
+                    call fIrrInfo_write(trim(TempString))
+                else
+                    write(TempString, '(5i6, i5, f8.1, i6)') &
+                    Di, Mi, Yi, i, undef_int, &
+                    IRRmm, undef_int
+                    call fIrrInfo_write(trim(TempString))
+                end if
+            end do
+            if (IrriON .eqv. .true.) then
+                call SetLastIrriDAP(DAPi)
+            end if
+        end if
+    end if
+end subroutine WriteIrrInfo
+
+
 subroutine FileManagement()
 
     integer(int32) :: RepeatToDay
@@ -7814,5 +7847,7 @@ subroutine RunSimulation(TheProjectFile_, TheProjectType)
 
     call FinalizeSimulation()
 end subroutine RunSimulation
+
+
 
 end module ac_run

--- a/src/run.f90
+++ b/src/run.f90
@@ -3880,7 +3880,6 @@ subroutine RelationshipsForFertilityAndSaltStress()
     real(dp) :: Coeffb0Salt_temp
     real(dp) :: Coeffb1Salt_temp
     real(dp) :: Coeffb2Salt_temp
-
     real(dp) :: X10, X20, X30, X40, X50, X60, X70, X80, X90
     integer(int8) :: BioTop, BioLow
     real(dp) :: StrTop, StrLow
@@ -3890,6 +3889,9 @@ subroutine RelationshipsForFertilityAndSaltStress()
 
     ! 1.a Soil fertility (Coeffb0,Coeffb1,Coeffb2 : Biomass-Soil Fertility stress)
     if (GetCrop_StressResponse_Calibrated()) then
+        Coeffb0_temp = GetCoeffb0()
+        Coeffb1_temp = GetCoeffb1()
+        Coeffb2_temp = GetCoeffb2()
         call ReferenceStressBiomassRelationship(GetCrop_DaysToCCini(), &
                                   GetCrop_GDDaysToCCini(), &
                                   GetCrop_DaysToGermination(), &
@@ -3921,9 +3923,6 @@ subroutine RelationshipsForFertilityAndSaltStress()
         call SetCoeffb0(Coeffb0_temp)
         call SetCoeffb1(Coeffb1_temp)
         call SetCoeffb2(Coeffb2_temp)
-        WRITE(*, '(A, f10.2)') 'The value of Coeffb0_temp is:', Coeffb0_temp
-        WRITE(*, '(A, f10.2)') 'The value of Coeffb0_temp is:', Coeffb1_temp
-        WRITE(*, '(A, f10.2)') 'The value of Coeffb0_temp is:', Coeffb2_temp
     else
         call SetCoeffb0(real(undef_int, kind=dp))
         call SetCoeffb1(real(undef_int, kind=dp))
@@ -3957,6 +3956,9 @@ subroutine RelationshipsForFertilityAndSaltStress()
 
     ! 2. soil salinity (Coeffb0Salt,Coeffb1Salt,Coeffb2Salt : CCx/KsSto - Salt stress)
     if (GetSimulation_SalinityConsidered() .eqv. .true.) then
+        Coeffb0Salt_temp = GetCoeffb0Salt()
+        Coeffb1Salt_temp = GetCoeffb1Salt()
+        Coeffb2Salt_temp = GetCoeffb2Salt()
         call ReferenceCCxSaltStressRelationship(GetCrop_DaysToCCini(), &
                                   GetCrop_GDDaysToCCini(), &
                                   GetCrop_DaysToGermination(), &
@@ -7754,7 +7756,7 @@ subroutine WriteIrrInfo()
     end if
     if ((GetDayNri() < GetCrop_Day1()) .or. &
         (GetDayNri() > GetCrop_DayN())) then ! before and after growing period
-        write(TempString, '(5i6, i5, f8.1, i6)') &
+        write(TempString, '(5i6, f8.1, i6)') &
            Di, Mi, Yi, undef_int, undef_int, &
            GetIrrigation(), undef_int
         call fIrrInfo_write(trim(TempString))
@@ -7782,12 +7784,12 @@ subroutine WriteIrrInfo()
                     IrriON = .false.
                 end if
                 if (IrriON .eqv. .true.) then
-                    write(TempString, '(5i6, i5, f8.1, i6)') &
+                    write(TempString, '(5i6, f8.1, i6)') &
                     Di, Mi, Yi, i, undef_int, &
                     IRRmm, (DAPi - GetLastIrriDAP())
                     call fIrrInfo_write(trim(TempString))
                 else
-                    write(TempString, '(5i6, i5, f8.1, i6)') &
+                    write(TempString, '(5i6, f8.1, i6)') &
                     Di, Mi, Yi, i, undef_int, &
                     IRRmm, undef_int
                     call fIrrInfo_write(trim(TempString))

--- a/src/run.f90
+++ b/src/run.f90
@@ -5,6 +5,7 @@ use ac_climprocessing, only:    GetDecadeEToDataset, &
                                 GetMonthlyEToDataset, &
                                 GetMonthlyRainDataset
 use ac_global, only:    AdjustSizeCompartments, &
+                        ac_zero_threshold, &
                         GetCrop_DaysToHIo, &
                         GetCrop_GDDaysToHIo, &
                         GetOut8Irri, &
@@ -7022,7 +7023,7 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
         call DetermineRootZoneWC(GetRootingDepth(), SWCtopSoilConsidered_temp)
         call SetSimulation_SWCtopSoilConsidered(SWCtopSoilConsidered_temp)
         ! temperature stress affecting crop transpiration
-        if (GetCCiActual() <= 0.000001_dp) then
+        if (GetCCiActual() <= ac_zero_threshold) then
              KsTr = 1._dp
         else
              KsTr = KsTemperature(0._dp, GetCrop_GDtranspLow(), GetGDDayi())
@@ -7236,14 +7237,14 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
     ! 14.b Stress totals
     if (GetCCiActual() > 0._dp) then
         ! leaf expansion growth
-        if (GetStressLeaf() > - 0.000001_dp) then
+        if (GetStressLeaf() > - ac_zero_threshold) then
             call SetStressTot_Exp(((GetStressTot_NrD() - 1._dp)*GetStressTot_Exp() &
                      + GetStressLeaf())/real(GetStressTot_NrD(), kind=dp))
         end if
         ! stomatal closure
         if (GetTpot() > 0._dp) then
             StressStomata = 100._dp *(1._dp - GetTact()/GetTpot())
-            if (StressStomata > - 0.000001_dp) then
+            if (StressStomata > - ac_zero_threshold) then
                 call SetStressTot_Sto(((GetStressTot_NrD() - 1._dp) &
                     * GetStressTot_Sto() + StressStomata) / &
                     real(GetStressTot_NrD(), kind=dp))
@@ -7251,7 +7252,7 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
         end if
     end if
     ! weed stress
-    if (GetWeedRCi() > - 0.000001_dp) then
+    if (GetWeedRCi() > - ac_zero_threshold) then
         call SetStressTot_Weed(((GetStressTot_NrD() - 1._dp)*GetStressTot_Weed() &
              + GetWeedRCi())/real(GetStressTot_NrD(), kind=dp))
     end if
@@ -7508,7 +7509,7 @@ subroutine WriteDailyResults(DAP, WPi)
         end if
 
         ! 4. Air temperature stress
-        if (GetCCiActual() <= 0.000001_dp) then
+        if (GetCCiActual() <= ac_zero_threshold) then
             KsTr = 1._dp
         else
             KsTr = KsTemperature(0._dp, GetCrop_GDtranspLow(), GetGDDayi())
@@ -7521,14 +7522,14 @@ subroutine WriteDailyResults(DAP, WPi)
         end if
 
         ! 5. Relative cover of weeds
-        if (GetCCiActual() <= 0.000001_dp) then
+        if (GetCCiActual() <= ac_zero_threshold) then
             StrW = undef_int
         else
             StrW = roundc(GetWeedRCi(), mold=1)
         end if
 
         ! 6. WPi adjustemnt
-        if (GetSumWaBal_Biomass() <= 0.000001_dp) then
+        if (GetSumWaBal_Biomass() <= ac_zero_threshold) then
             WPi_loc = 0._dp
         end if
 

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -3534,7 +3534,7 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
                     ! (soil fertility/salinity stress) further in late season
                     if (GetCrop_GDDaysToSenescence() <= GetCrop_GDDaysToFullCanopySF()) then
                         CCibis = GetCCiActual()
-                    else:
+                    else
                         CCibis = CCxSF &
                                 - (RatDGDD*GetSimulation_EffectStress_CDecline() &
                                                                        /100._dp) &

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -583,8 +583,8 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
     real(dp), intent(inout) :: WeedRCi
     real(dp), intent(inout) :: CCw
     real(dp), intent(inout) :: Trw
-    integer(int8), intent(inout) :: StressSFadjNEW
-    integer(int8), intent(inout) :: PreviousStressLevel
+    integer(int32), intent(inout) :: StressSFadjNEW
+    integer(int32), intent(inout) :: PreviousStressLevel
     logical, intent(inout) :: StoreAssimilates
     logical, intent(inout) :: MobilizeAssimilates
     real(dp), intent(inout) :: AssimToMobilize
@@ -1037,7 +1037,7 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
           DiFlor = (dayi-1) - (GetSimulation_DelayedDays() + &
                             GetCrop_Day1() + GetCrop_DaysToFlowering())
           f1 = FractionPeriod(DiFlor)
-          if (abs(f1-f2) < 0.0000001_dp) then
+          if (abs(f1-f2) < 0.000001_dp) then
               F = 0._dp
           else
               F = (100._dp * ((f1+f2)/2._dp)/GetCrop_LengthFlowering())
@@ -3401,7 +3401,7 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
             else
                 if (GetCCiPrev() < (0.97999_dp*CCxSF)) then
                     call DetermineGDDCGCadjusted(GDDCGCadjusted)
-                    if (GDDCGCadjusted > 0.00000001_dp) then
+                    if (GDDCGCadjusted > 0.000001_dp) then
                         ! Crop.GDDCGC or GDDCGCadjusted > 0
                         Crop_CCxAdjusted_temp = GetCrop_CCxAdjusted()
                         call DetermineCCxAdjusted(Crop_CCxAdjusted_temp)
@@ -3957,7 +3957,7 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
                                  * (1._dp - exp(8._dp*log(KsSen)))
                 StressSenescence = 100._dp * (1._dp - KsSen)
             else
-                GDDCDCadjusted = 0._dp
+                GDDCDCadjusted = 0.0001_dp ! extreme small decline
                 StressSenescence = 0._dp
             end if
         end if
@@ -3986,7 +3986,7 @@ subroutine EffectSoilFertilitySalinityStress(StressSFadjNEW, Coeffb0Salt, &
                                              Coeffb1Salt, Coeffb2Salt, &
                                              NrDayGrow, StressTotSaltPrev, &
                                              VirtualTimeCC)
-    integer(int8), intent(inout) :: StressSFadjNEW
+    integer(int32), intent(inout) :: StressSFadjNEW
     real(dp), intent(in) :: Coeffb0Salt, Coeffb1Salt, Coeffb2Salt
     integer(int32), intent(in) :: NrDayGrow
     real(dp), intent(in) :: StressTotSaltPrev
@@ -4142,7 +4142,7 @@ subroutine PrepareStage1()
 
     Soil_temp = GetSoil()
 
-    if (GetSurfaceStorage() > 0.0000001_dp) then
+    if (GetSurfaceStorage() > 0.000001_dp) then
         call SetSimulation_EvapWCsurf(Soil_temp%REW*1._dp)
     else
         call SetSimulation_EvapWCsurf(GetRain() + GetIrrigation() - GetRunOff())
@@ -4423,7 +4423,7 @@ subroutine ExtractWaterFromEvapLayer(EvapToLose, Zact, Stg1)
         end if
         Ztot = Ztot + fracZ * (GetCompartment_Thickness(compi))
         if ((Compi >= GetNrCompartments()) &
-            .or. (abs(StillToExtract) < 0.0000001_dp) &
+            .or. (abs(StillToExtract) < 0.000001_dp) &
             .or. (Ztot >= 0.999999_dp*Zact)) exit loop
     end do loop
     if (Stg1) then
@@ -4449,7 +4449,7 @@ subroutine CalculateSoilEvaporationStage1()
         call ExtractWaterFromEvapLayer(GetSimulation_EvapWCsurf(), EvapZmin, &
                                                                        Stg1)
     end if
-    if (GetSimulation_EvapWCsurf() < 0.0000001_dp) then
+    if (GetSimulation_EvapWCsurf() < 0.000001_dp) then
         call PrepareStage2()
     end if
 end subroutine CalculateSoilEvaporationStage1
@@ -4770,7 +4770,7 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
             else
                 if (GetCCiPrev() < 0.97999_dp*CCxSF) then
                     call DetermineCGCadjusted(CGCadjusted)
-                    if (CGCadjusted > 0.00000001_dp) then
+                    if (CGCadjusted > 0.000001_dp) then
                         ! CGCSF or CGCadjusted > 0
                         Crop_CCxAdjusted_temp = GetCrop_CCxAdjusted()
                         call DetermineCCxAdjusted(Crop_CCxAdjusted_temp)
@@ -5448,7 +5448,7 @@ subroutine BUDGET_module(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC, &
     real(dp), intent(in) :: DayFraction
     real(dp), intent(in) :: GDDayFraction
     real(dp), intent(in) :: FracAssim
-    integer(int8), intent(in) :: StressSFadjNEW
+    integer(int32), intent(in) :: StressSFadjNEW
     logical, intent(in) :: StorageON
     logical, intent(in) :: MobilizationON
     real(dp), intent(inout) :: StressLeaf
@@ -5473,7 +5473,7 @@ subroutine BUDGET_module(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC, &
     real(dp) :: Crop_pActStom_temp
     real(dp) :: CRsalt_temp, ECdrain_temp, Tact_temp, Surf0_temp
     integer(int32) :: TargetTimeVal_loc
-    integer(int8) :: StressSFadjNEW_loc
+    integer(int32) :: StressSFadjNEW_loc
 
     TargetTimeVal_loc = TargetTimeVal
     StressSFadjNEW_loc = StressSFadjNEW
@@ -5639,12 +5639,12 @@ subroutine BUDGET_module(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC, &
             call CalculateEvaporationSurfaceWater
         end if
         ! stage 1 evaporation
-        if ((abs(GetEpot() - GetEact()) > 0.0000001_dp) &
+        if ((abs(GetEpot() - GetEact()) > 0.000001_dp) &
             .and. (GetSimulation_EvapWCsurf() > 0._dp)) then
             call CalculateSoilEvaporationStage1()
         end if
         ! stage 2 evaporation
-        if (abs(GetEpot() - GetEact()) > 0.0000001_dp) then
+        if (abs(GetEpot() - GetEact()) > 0.000001_dp) then
             call CalculateSoilEvaporationStage2()
         end if
     end if

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -3532,14 +3532,18 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
                     ! calculate CC in late season
                     ! CCibis = CC which canopy declines
                     ! (soil fertility/salinity stress) further in late season
-                    CCibis = CCxSF &
-                            - (RatDGDD*GetSimulation_EffectStress_CDecline() &
-                                                                   /100._dp) &
-                            * (exp(2._dp &
-                                  * log(SumGDDadjCC &
-                                        - GetCrop_GDDaysToFullCanopySF())) &
-                                /(GetCrop_GDDaysToSenescence() &
-                                    - GetCrop_GDDaysToFullCanopySF()))
+                    if (GetCrop_GDDaysToSenescence() <= GetCrop_GDDaysToFullCanopySF()) then
+                        CCibis = GetCCiActual()
+                    else:
+                        CCibis = CCxSF &
+                                - (RatDGDD*GetSimulation_EffectStress_CDecline() &
+                                                                       /100._dp) &
+                                * (exp(2._dp &
+                                      * log(SumGDDadjCC &
+                                            - GetCrop_GDDaysToFullCanopySF())) &
+                                    /(GetCrop_GDDaysToSenescence() &
+                                        - GetCrop_GDDaysToFullCanopySF()))
+                    end if
                     if (CCibis < 0._dp) then
                         call SetCCiActual(0._dp)
                     else

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -1525,7 +1525,7 @@ subroutine surface_transpiration(Coeffb0Salt, Coeffb1Salt, Coeffb2Salt)
     real(dp), intent(in) :: Coeffb1Salt
     real(dp), intent(in) :: Coeffb2Salt
 
-    real(dp) :: Textra, Part
+    real(dp) :: Part
     integer(int32) :: compi
     real(dp) :: KsReduction, SaltSurface
     real(dp) :: Tact_temp
@@ -5031,10 +5031,10 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
                     else
                         ! CDC is adjusted to degree of stress
                         ! time required to reach CCiprev with CDCadjusted
-                        if (GetCCiTopEarlySen()== 0._dp) then
+                        if (abs(GetCCiTopEarlySen()) < epsilon(0._dp)) then
                             call SetCCiTopEarlySen(epsilon(1._dp))
                         end if
-                        if (CDCadjusted == 0._dp) then
+                        if (abs(CDCadjusted) < epsilon(0._dp)) then
                             CDCadjusted = epsilon(1._dp)
                         end if
                         tTemp = (log(1._dp &
@@ -5466,12 +5466,11 @@ subroutine BUDGET_module(dayi, TargetTimeVal, TargetDepthVal, VirtualTimeCC, &
         !! EC of the infiltrated water (surface storage)
     logical :: WaterTableInProfile
     real(dp) :: HorizontalWaterFlow, HorizontalSaltFlow
-    type(rep_EffectStress) :: EffectStress_temp
     logical :: SWCtopSoilConsidered_temp
     real(dp) :: EvapWCsurf_temp, CRwater_temp, Tpot_temp, Epot_temp
     type(CompartmentIndividual), dimension(max_No_compartments) :: Comp_temp
     real(dp) :: Crop_pActStom_temp
-    real(dp) :: CRsalt_temp, ECdrain_temp, Tact_temp, Surf0_temp
+    real(dp) :: CRsalt_temp, ECdrain_temp, Surf0_temp
     integer(int32) :: TargetTimeVal_loc
     integer(int32) :: StressSFadjNEW_loc
 

--- a/src/startunit.F90
+++ b/src/startunit.F90
@@ -11,6 +11,7 @@ use ac_global, only:    undef_int, &
                         SetOut5CompWC, &
                         SetOut6CompEC, &
                         SetOut7Clim, &
+                        SetOut8Irri, &
                         SetOutDaily, &
                         SetPart1Mult, &
                         SetPart2Eval, &
@@ -22,6 +23,7 @@ use ac_global, only:    undef_int, &
                         GetOut5CompWC, &
                         GetOut6CompEC, &
                         GetOut7Clim, &
+                        GetOut8Irri, &
                         GetPathNameOutp, &
                         GetOutputAggregate, &
                         GetPart1Mult, &
@@ -46,6 +48,7 @@ use ac_global, only:    undef_int, &
                         SetOut5CompWC, &
                         SetOut6CompEC, &
                         SetOut7Clim, &
+                        SetOut8Irri, &
                         SetOutDaily, &
                         SetPart1Mult, &
                         SetPart2Eval, &
@@ -57,6 +60,7 @@ use ac_global, only:    undef_int, &
                         GetOut5CompWC, &
                         GetOut6CompEC, &
                         GetOut7Clim, &
+                        GetOut8Irri, &
                         GetPathNameOutp, &
                         GetOutputAggregate, &
                         GetPart1Mult, &
@@ -102,6 +106,7 @@ use ac_global, only:    undef_int, &
                         SetSimulParam_IniAbstract, &
                         SetSimulParam_Tmin, &
                         SetTmin, &
+                        SetTmax, &
                         SetSimulParam_Tmax, &
                         SetSimulParam_GDDMethod, &
                         SetSimulParam_EffectiveRain_Method, &
@@ -129,12 +134,12 @@ use ac_kinds, only: int32,&
                     dp
 use ac_project_input, only: GetNumberSimulationRuns, &
                             initialize_project_input
-use ac_run, only: open_file, &
-                  RunSimulation, &
-                  write_file
+use ac_run, only:   RunSimulation
 use ac_utils, only: assert, &
                     upper_case, &
-                    int2str
+                    write_file, &
+                    int2str, &
+                    open_file
 use iso_fortran_env, only: iostat_end
 implicit none
 
@@ -198,6 +203,7 @@ subroutine GetRequestDailyResults()
     call SetOut5CompWC(.false.)
     call SetOut6CompEC(.false.)
     call SetOut7Clim(.false.)
+    call SetOut8Irri(.false.)
 
     FullFileName = GetPathNameSimul() // 'DailyResults.SIM'
     if (FileExists(FullFileName) .eqv. .true.) then
@@ -230,6 +236,9 @@ subroutine GetRequestDailyResults()
                 end if
                 if (TempString(i:i) == '7') then
                     call SetOut7Clim(.true.)
+                end if
+                if (TempString(i:i) == '8') then
+                    call SetOut8Irri(.true.)
                 end if
             end if
             if (rc == iostat_end) exit loop
@@ -367,7 +376,7 @@ subroutine PrepareReport()
         call fProjects_write('None created')
     end select
     call fProjects_write('')
-    if (GetOutDaily()) then
+    if (GetOutDaily() .and. GetOut8Irri()) then
         call fProjects_write('Daily output results:')
         if (GetOut1Wabal()) then
             call fProjects_write('1. - soil water balance')
@@ -393,6 +402,9 @@ subroutine PrepareReport()
         end if
         if (GetOut7Clim()) then
             call fProjects_write('7. - climate input parameters')
+        end if
+        if (GetOut8Irri()) then
+            call fProjects_write('8. - irrigation events and intervals')
         end if
     else
         call fProjects_write('Daily output results: None created')
@@ -857,15 +869,15 @@ subroutine LoadProgramParametersProjectPlugIn(&
             ! with equations for CN AMCII and CN converions
 
         ! Temperature
-        read(f0, *) Tmin_temp
+        read(f0, *) simul_Tmi
             ! Default minimum temperature (degC) if no
             ! temperature file is specified
-        call SetTmin(Tmin_temp)
+        call SetTmin(simul_Tmi)
         call SetSimulParam_Tmin(simul_Tmi)
         read(f0, *) simul_Tma
             ! Default maximum temperature (degC) if
             ! no temperature file is specified
-
+        call SetTmax(simul_Tma)
         call SetSimulParam_Tmax(simul_Tma)
         read(f0, *) simul_GDD ! Default method for GDD calculations
         call SetSimulParam_GDDMethod(simul_GDD)

--- a/src/startunit.F90
+++ b/src/startunit.F90
@@ -789,7 +789,7 @@ subroutine LoadProgramParametersProjectPlugIn(&
                     simul_ed, simul_pCCHIf, simul_SFR, simul_TAWg, &
                     simul_beta, simul_Tswc, simul_EZma, simul_GDD
     real(dp) :: simul_rod, simul_kcWB, simul_RZEma, simul_pfao, &
-                simul_expFsen, simul_Tmi, simul_Tma, Tmin_temp
+                simul_expFsen, simul_Tmi, simul_Tma
 
     if (FileExists(FullFileNameProgramParameters)) then
         ! load set of program parameters

--- a/src/startunit.F90
+++ b/src/startunit.F90
@@ -376,7 +376,7 @@ subroutine PrepareReport()
         call fProjects_write('None created')
     end select
     call fProjects_write('')
-    if (GetOutDaily() .and. GetOut8Irri()) then
+    if (GetOutDaily() .or. GetOut8Irri()) then
         call fProjects_write('Daily output results:')
         if (GetOut1Wabal()) then
             call fProjects_write('1. - soil water balance')

--- a/src/tempprocessing.f90
+++ b/src/tempprocessing.f90
@@ -1,19 +1,19 @@
 module ac_tempprocessing
 
 use ac_global , only: undef_int, &
-                        GetTmaxTnxReference12MonthsRun_i,&
-                        GetTminTnxReference12MonthsRun_i,&
-                        GetTmaxTnxReference12MonthsRun,&
-                        GetTminTnxReference12MonthsRun,&
-                        SetTmaxTnxReference12MonthsRun_i,&
-                        SetTminTnxReference12MonthsRun_i,&
-                        SetTmaxTnxReference12MonthsRun,&
-                        SetTminTnxReference12MonthsRun,&
-                    fTnxReference,&
-                    fTnxReference_iostat,&
-                    fTnxReference365Days,& 
-                    fTnxReference365Days_iostat,&
-                    GetTnxReference365DaysFileFull,&
+                      GetTmaxTnxReference12MonthsRun_i,&
+                      GetTminTnxReference12MonthsRun_i,&
+                      GetTmaxTnxReference12MonthsRun,&
+                      GetTminTnxReference12MonthsRun,&
+                      SetTmaxTnxReference12MonthsRun_i,&
+                      SetTminTnxReference12MonthsRun_i,&
+                      SetTmaxTnxReference12MonthsRun,&
+                      SetTminTnxReference12MonthsRun,&
+                      fTnxReference,&
+                      fTnxReference_iostat,&
+                      fTnxReference365Days,& 
+                      fTnxReference365Days_iostat,&
+                      GetTnxReference365DaysFileFull,&
                       modeCycle_GDDays, &
                       modeCycle_CalendarDays, &
                       DaysinMonth, &
@@ -310,7 +310,6 @@ use ac_global , only: undef_int, &
                       TmaxTnxReference365DaysRun, &
                       TminCropReferenceRun, &
                       TmaxCropReferenceRun
-
 use ac_kinds,  only: sp,&
                      dp, &
                      int8, &
@@ -355,78 +354,6 @@ subroutine AdjustDecadeMONTHandYEAR(DecFile, Mfile, Yfile)
     end if
 end subroutine AdjustDecadeMONTHandYEAR
 
-
-!subroutine ReadTnxReference365DaysFilefull()
-!    !! Reads the contents of the TnxReference365DaysFilefull file,
-!    !! storing the temperatures in the TminTnxReference365Days and TmaxTnxReference365Days arrays.
-!
-!    character(len=:), allocatable :: filename
-!    integer :: fhandle, i, nlines, nrows, rc
-!
-!    filename = trim(GetPathNameSimul()) // 'TnxReference365Days.SIM'
-!    open(newunit=fhandle, file=trim(filename), status='old', action='read')
-!
-!    ! Count the number of lines
-!    nlines = 0
-!    do
-!        read(fhandle, '(a)', iostat=rc)
-!        if (rc == iostat_end) then
-!            exit
-!        else
-!            nlines = nlines + 1
-!        end if
-!    end do
-!
-!    ! Now read in the actual content
-!    nrows = nlines - 8
-!    if (allocated(TminTnxReference365DaysRun)) deallocate(TminTnxReference365DaysRun)
-!    if (allocated(TminTnxReference365DaysRun)) deallocate(TmaxTnxReference365DaysRun)
-!    allocate(TminTnxReference365DaysRun(nrows), TmaxTnxReference365DaysRun(nrows))
-!
-!    rewind(fhandle)
-!    do i = 1, nrows
-!        read(fhandle, *) TminTnxReference365DaysRun(i), TmaxTnxReference365DaysRun(i)
-!    end do
-!
-!    close(fhandle)
-!end subroutine ReadTnxReference365DaysFilefull
-
-!
-!subroutine ReadTCropReferenceFilefull()
-!    !! Reads the contents of the TCropReferenceFilefull file,
-!    !! storing the temperatures in the TminCropReference and TmaxCropReference arrays.
-!
-!    character(len=:), allocatable :: filename
-!    integer :: fhandle, i, nlines, nrows, rc
-!
-!    filename = trim(GetPathNameSimul()) // 'TCropReference.SIM'
-!    open(newunit=fhandle, file=trim(filename), status='old', action='read')
-!
-!    ! Count the number of lines
-!    nlines = 0
-!    do
-!        read(fhandle, '(a)', iostat=rc)
-!        if (rc == iostat_end) then
-!            exit
-!        else
-!            nlines = nlines + 1
-!        end if
-!    end do
-!
-!    ! Now read in the actual content
-!    nrows = nlines - 8
-!    if (allocated(TminCropReference)) deallocate(TminCropReference)
-!    if (allocated(TminCropReference)) deallocate(TmaxCropReference)
-!    allocate(TminCropReference(nrows), TmaxCropReference(nrows))
-!
-!    rewind(fhandle)
-!    do i = 1, nrows
-!        read(fhandle, *) TminCropReference(i), TmaxCropReference(i)
-!    end do
-!
-!    close(fhandle)
-!end subroutine ReadTCropReferenceFilefull
-!
 
 subroutine ReadTemperatureFilefull()
     !! Reads the contents of the TemperatureFilefull file,
@@ -2201,9 +2128,11 @@ subroutine LoadSimulationRunProject(NrRun)
         call CompleteClimateDescription(temperature_record)
         call SetTemperatureRecord(temperature_record)
     end if
-
+/
     ! Create Temperature Reference file 
-    call CreateTnxReferenceFile(GetTemperatureFile(),GetTnxReferenceFile(),GetTnxReferenceYear());
+    if (GetTemperatureFile() /= '(External)') then
+        call CreateTnxReferenceFile(GetTemperatureFile(),GetTnxReferenceFile(),GetTnxReferenceYear());
+    end if
     call CreateTnxReference365Days();
 
     ! 1.2 ETo
@@ -3157,7 +3086,6 @@ real(dp) function Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
 end function Bnormalized
 
 
-
 subroutine CreateTnxReference365Days()
 
     character(len=:), allocatable :: totalnameOUT
@@ -3165,46 +3093,43 @@ subroutine CreateTnxReference365Days()
     integer(int32) :: DayNri
     integer(int32) :: i, Monthi
     type(rep_DayEventDbl), dimension(31) :: TminDataSet_temp,TmaxDataSet_temp
-    real(dp) :: Tlow, Thigh
+    real(sp) :: Tlow, Thigh
 
-    if (FileExists(GetTnxReferenceFileFull())) then
+    if ((FileExists(GetTnxReferenceFileFull())) .OR. (GetTnxReferenceFile() == '(External)')) then
         ! create SIM file
-        totalnameOUT = trim(GetPathNameSimul()) // 'TnxReference365Days.SIM'
-        call fTnxReference365Days_open(totalnameOUT, 'w')
+        if (GetTnxReferenceFile() /= '(External)') then
+            totalnameOUT = trim(GetPathNameSimul()) // 'TnxReference365Days.SIM'
+            call fTnxReference365Days_open(totalnameOUT, 'w')
+        end if
         
         ! get data set for 1st month
         Monthi = 1
         call GetMonthlyTemperatureDataSetFromTnxReferenceFile(Monthi, TminDataSet_temp, TmaxDataSet_temp)
-        !WRITE(*, '(A, 2f10.2)') 'TminDataSet_temp(1)%Param: ', TminDataSet_temp(1)%Param
-        !WRITE(*, '(A, 2f10.2)') 'TmaxDataSet_temp(1)%Param: ', TmaxDataSet_temp(1)%Param
         
         ! Tnx for Day 1 to 365
         do DayNri = 1, 365
-            !WRITE(*, '(A, i4)') 'TminDataSet_temp(31)%DayNr', TminDataSet_temp(31)%DayNr
-            !WRITE(*, '(A, i4)') 'DayNri', DayNri
             if (DayNri > TminDataSet_temp(31)%DayNr) then
                 ! next month
                 Monthi = Monthi + 1
-                !WRITE(*, '(A, i4)') 'next month', Monthi
                 call GetMonthlyTemperatureDataSetFromTnxReferenceFile(Monthi, TminDataSet_temp, TmaxDataSet_temp)
             end if
             i = 1
-            !WRITE(*, '(A,i4)') 'DayNri', DayNri
             do while (TminDataSet_temp(i)%DayNr /= DayNri)
-                !WRITE(*, '(i4)') i
-                !WRITE(*, '(i4)') TminDataSet_temp(i)%DayNr
-                !WRITE(*, '(i4)') DayNri
                 i = i+1
             end do
-            Tlow = real(roundc(100*TminDataSet_temp(i)%Param, mold=int32),kind=dp)/100._dp
-            Thigh = real(roundc(100*TmaxDataSet_temp(i)%Param, mold=int32),kind=dp)/100._dp
-            write(TempString, '(2f10.2)') Tlow, Thigh
+            Tlow = real(roundc(100*TminDataSet_temp(i)%Param, mold=int32),kind=sp)/100._sp
+            Thigh = real(roundc(100*TmaxDataSet_temp(i)%Param, mold=int32),kind=sp)/100._sp
             call SetTminTnxReference365DaysRun_i(DayNri,Tlow)
             call SetTmaxTnxReference365DaysRun_i(DayNri,Thigh)
-            call fTnxReference365Days_write(trim(TempString))
+            if (GetTnxReferenceFile() /= '(External)') then
+                write(TempString, '(2f10.2)') Tlow, Thigh
+                call fTnxReference365Days_write(trim(TempString))
+            end if
         end do
-        ! Close file
-        call fTnxReference365Days_close()
+        if (GetTnxReferenceFile() /= '(External)') then
+            ! Close file
+            call fTnxReference365Days_close()
+        end if
     end if
 end subroutine CreateTnxReference365Days
 
@@ -3249,7 +3174,6 @@ subroutine CreateTnxReferenceFile(TemperatureFile, TnxReferenceFile, TnxReferenc
         ! 2.a Preparation
         ! Get Number of Years
         NrYears = GetTemperatureRecord_ToY() - GetTemperatureRecord_FromY() + 1
-        !WRITE(*, '(A, i4)') 'The value of NrYears is:', NrYears
         ! Get TnxReferenceYear
         call SetTnxReferenceYear(roundc((GetTemperatureRecord_FromY()+GetTemperatureRecord_ToY())/2._dp,mold=1_int32))
         if (GetTnxReferenceYear() == 1901) then
@@ -3314,8 +3238,6 @@ subroutine CreateTnxReferenceFile(TemperatureFile, TnxReferenceFile, TnxReferenc
             ! read data
             read(fhandle, *, iostat=rc) Val1, Val2 ! Tmin, Tmax
             if (rc == iostat_end) exit
-            !WRITE(*, '(A, f10.2)') 'The value of Val1 is:', Val1
-            !WRITE(*, '(A, f10.2)') 'The value of Val2 is:', Val2
             SUM1 = SUM1 + Val1 ! minimum temperature
             SUM2 = SUM2 + Val2 ! maximum temperature
             ! check end of month
@@ -3341,9 +3263,6 @@ subroutine CreateTnxReferenceFile(TemperatureFile, TnxReferenceFile, TnxReferenc
                 ! mean monthly values Tmin and Tmax
                 select case (GetTemperatureRecord_DataType())
                 case (datatype_daily)
-            !WRITE(*, '(A, f10.2)') 'The value of SUM1 is:', SUM1
-            !WRITE(*, '(A, f10.2)') 'The value of SUM2 is:', SUM2
-            !WRITE(*, '(A, I4)') 'The value of MonthDays is:', MonthDays
                     SUM1 = SUM1/real(MonthDays, kind=dp)
                     SUM2 = SUM2/real(MonthDays, kind=dp)
                 case (datatype_decadely)
@@ -3352,9 +3271,6 @@ subroutine CreateTnxReferenceFile(TemperatureFile, TnxReferenceFile, TnxReferenc
                 end select
                 MonthVal1(Monthi) = MonthVal1(Monthi) + SUM1/real(MonthNrYears(Monthi),kind=dp) ! Tmin
                 MonthVal2(Monthi) = MonthVal2(Monthi) + SUM2/real(MonthNrYears(Monthi),kind=dp) ! Tmax
-                !WRITE(*, '(A, i4)') 'The value of Monthi is:', Monthi
-                !WRITE(*, '(A, f10.4)') 'The value of MonthVal1 is:', MonthVal1(Monthi)
-                !WRITE(*, '(A, f10.4)') 'The value of MonthVal2 is:', MonthVal2(Monthi)
                 ! Next month
                 SUM1 = 0._dp
                 SUM2 = 0._dp
@@ -3410,13 +3326,12 @@ subroutine CreateTnxReferenceFile(TemperatureFile, TnxReferenceFile, TnxReferenc
         do Monthi = 1, 12
             write(TempString2, '(2f10.2)') MonthVal1(Monthi), MonthVal2(Monthi)
             call fTnxReference_write(trim(TempString2))
-            call SetTminTnxReference12MonthsRun_i(Monthi,real(roundc(100*MonthVal1(Monthi),mold=int32),kind=dp)/100._dp)
-            call SetTmaxTnxReference12MonthsRun_i(Monthi,real(roundc(100*MonthVal2(Monthi),mold=int32),kind=dp)/100._dp)
+            call SetTminTnxReference12MonthsRun_i(Monthi,real(roundc(100*MonthVal1(Monthi),mold=int32),kind=sp)/100._sp)
+            call SetTmaxTnxReference12MonthsRun_i(Monthi,real(roundc(100*MonthVal2(Monthi),mold=int32),kind=sp)/100._sp)
         end do
         call fTnxReference_close()
     end if
 end subroutine CreateTnxReferenceFile
-
 
 !TminDatSet
 
@@ -3643,12 +3558,9 @@ subroutine GetMonthlyTemperatureDataSetFromTnxReferenceFile(Monthi, TminDataSet,
     real(dp) :: C1Max, C2Max, C3Max
     real(dp) :: aOver3Min, bOver2Min, cMin
     real(dp) :: aOver3Max, bOver2Max, cMax
-    character(len=:), allocatable :: FullFileName
 
     ni=30
 
-    !call GetSetofThreeMonthsUndefYear(Monthi, &
-    !     C1Min, C2Min, C3Min, C1Max, C2Max, C3Max)
     if (Monthi == 1) then
         C1Min = GetTminTnxReference12MonthsRun_i(12)
         C1Max = GetTmaxTnxReference12MonthsRun_i(12)
@@ -3680,7 +3592,6 @@ subroutine GetMonthlyTemperatureDataSetFromTnxReferenceFile(Monthi, TminDataSet,
                    aOver3Min, bOver2Min, cMin)
     call GetInterpolationParameters(C1Max, C2Max, C3Max, &
                    aOver3Max, bOver2Max, cMax)
-        !WRITE(*, '(A, 6f10.2)') 'Int C1Min ...: ', C1Min, C2Min, C3Min, aOver3Min, bOver2Min, cMin
 
     t1 = 30
     do Dayi = 1, DayN
@@ -3692,7 +3603,6 @@ subroutine GetMonthlyTemperatureDataSetFromTnxReferenceFile(Monthi, TminDataSet,
         TmaxDataSet(Dayi)%Param = aOver3Max*(t2*t2*t2-t1*t1*t1) &
             + bOver2Max*(t2*t2-t1*t1) + cMax*(t2-t1)
         t1 = t2
-        !WRITE(*, '(A, i4, f10.2)') 'TminDataSet(Dayi)%DayNr: ', TminDataSet(Dayi)%DayNr, TminDataSet(Dayi)%Param
     end do
     do Dayi = (DayN+1), 31 ! Give to remaining days (day 29,30 or 31) the DayNr of the last day of the month
         TminDataSet(Dayi)%DayNr = DNR+DayN-1
@@ -3702,112 +3612,6 @@ subroutine GetMonthlyTemperatureDataSetFromTnxReferenceFile(Monthi, TminDataSet,
     end do
 
     contains
-
-
-!    subroutine GetSetofThreeMonthsUndefYear(Monthi, &
-!            C1Min, C2Min, C3Min, C1Max, C2Max, C3Max)
-!        integer(int32), intent(in) :: Monthi
-!        real(dp), intent(inout) :: C1Min
-!        real(dp), intent(inout) :: C2Min
-!        real(dp), intent(inout) :: C3Min
-!        real(dp), intent(inout) :: C1Max
-!        real(dp), intent(inout) :: C2Max
-!        real(dp), intent(inout) :: C3Max
-!
-!        integer(int32) :: fhandle
-!        integer(int32) :: Mfile, Nri, Obsi, rc
-!        logical :: OK3
-!
-!        ! 1. Prepare record
-!        open(newunit=fhandle, file=trim(GetTnxReferenceFileFull()), &
-!                     status='old', action='read', iostat=rc)
-!        read(fhandle, *, iostat=rc) ! description
-!        read(fhandle, *, iostat=rc) ! time step
-!        read(fhandle, *, iostat=rc) ! day
-!        read(fhandle, *, iostat=rc) ! month
-!        read(fhandle, *, iostat=rc) ! year
-!        read(fhandle, *, iostat=rc)
-!        read(fhandle, *, iostat=rc)
-!        read(fhandle, *, iostat=rc)
-!
-!        Mfile = 1
-!        OK3 = .false.
-!
-!        ! 2. If first month
-!        if (Monthi == 1) then
-!            ! get Tnx Month 12
-!            do Monthi = 1, 11
-!                read(fhandle, *, iostat=rc)
-!            end do
-!            call ReadMonth(C1Min, C1Max, fhandle, rc)
-!            ! reset
-!            rewind(fhandle)
-!            do Monthi = 1, 8
-!                read(fhandle, *, iostat=rc)
-!            end do
-!            ! get Tnx Month 1 and 2
-!            call ReadMonth(C2Min, C2Max, fhandle, rc)  ! month 1
-!            call ReadMonth(C3Min, C3Max, fhandle, rc)  ! month 2
-!            OK3 = .true.
-!        end if
-!        
-!        ! 3. If last month
-!        if (Monthi == 12) then
-!            ! get Tnx Month 11 and 12
-!            do Monthi = 1, 10
-!                read(fhandle, *, iostat=rc)
-!            end do
-!            call ReadMonth(C1Min, C1Max, fhandle, rc)  ! month 11
-!            call ReadMonth(C2Min, C2Max, fhandle, rc)  ! month 12
-!            ! reset
-!            rewind(fhandle)
-!            ! get Tnx Month 1
-!            do Monthi = 1, 8
-!                read(fhandle, *, iostat=rc)
-!            end do
-!            call ReadMonth(C3Min, C3Max, fhandle, rc)  ! month 1
-!            OK3 = .true.
-!        end if
-!        
-!        ! 4. IF not first or last month
-!        if(.not. OK3) then
-!            ! determine Position Monthi
-!            Obsi = 1
-!            do while (.not. OK3)
-!                if (Monthi == Mfile) then
-!                   OK3 = .true.
-!                else
-!                   Mfile = Mfile + 1
-!                  Obsi = Obsi + 1
-!                end if
-!            end do
-!            ! get to Monthi-1
-!            do Nri = 1, (Obsi-2)
-!                read(fhandle, *, iostat=rc)
-!            end do
-!            ! Get Tnx (Monthi-1), Monthi, (Monthi+1)
-!            call ReadMonth(C1Min, C1Max, fhandle, rc) ! Monthi-1
-!            call ReadMonth(C2Min, C2Max, fhandle, rc) ! Monthi
-!            call ReadMonth(C3Min, C3Max, fhandle, rc) ! Monthi+1
-!        end if
-!        close(fhandle)
-!    end subroutine GetSetofThreeMonthsUndefYear
-!
-
-    subroutine ReadMonth(CiMin, CiMax, fhandle, rc)
-        real(dp), intent(inout) :: CiMin
-        real(dp), intent(inout) :: CiMax
-        integer(int32), intent(in) :: fhandle
-        integer(int32), intent(inout) :: rc
-
-        integer(int32), parameter :: ni = 30 ! simplification give better results for all cases
-        character(len=255) :: StringREAD
-
-        read(fhandle, '(a)', iostat=rc) StringREAD
-        call SplitStringInTwoParams(StringREAD, CiMin, CiMax)
-        CiMin = CiMin * ni
-        CiMax = CiMax * ni
-    end subroutine ReadMonth
 
 
     subroutine GetInterpolationParameters(C1, C2, C3, &
@@ -3825,7 +3629,5 @@ subroutine GetMonthlyTemperatureDataSetFromTnxReferenceFile(Monthi, TminDataSet,
         c = (11._dp*C1-7._dp*C2+2._dp*C3)/(6._dp*30._dp)
     end subroutine GetInterpolationParameters
 end subroutine GetMonthlyTemperatureDataSetFromTnxReferenceFile
-
-
 
 end module ac_tempprocessing

--- a/src/tempprocessing.f90
+++ b/src/tempprocessing.f90
@@ -1,6 +1,19 @@
 module ac_tempprocessing
 
 use ac_global , only: undef_int, &
+                        GetTmaxTnxReference12MonthsRun_i,&
+                        GetTminTnxReference12MonthsRun_i,&
+                        GetTmaxTnxReference12MonthsRun,&
+                        GetTminTnxReference12MonthsRun,&
+                        SetTmaxTnxReference12MonthsRun_i,&
+                        SetTminTnxReference12MonthsRun_i,&
+                        SetTmaxTnxReference12MonthsRun,&
+                        SetTminTnxReference12MonthsRun,&
+                    fTnxReference,&
+                    fTnxReference_iostat,&
+                    fTnxReference365Days,& 
+                    fTnxReference365Days_iostat,&
+                    GetTnxReference365DaysFileFull,&
                       modeCycle_GDDays, &
                       modeCycle_CalendarDays, &
                       DaysinMonth, &
@@ -270,21 +283,51 @@ use ac_global , only: undef_int, &
                       GetTminRun_i, &
                       GetTminRun, &
                       GetTmaxRun_i, &
-                      GetTmaxRun
+                      GetTmaxRun, &
+                      SetTminCropReferenceRun_i, &
+                      SetTminCropReferenceRun, &
+                      SetTmaxCropReferenceRun_i, &
+                      SetTmaxCropReferenceRun, &
+                      GetTminCropReferenceRun_i, &
+                      GetTminCropReferenceRun, &
+                      GetTmaxCropReferenceRun_i, &
+                      GetTmaxCropReferenceRun, &
+                      SetTminTnxReference365DaysRun_i, &
+                      SetTminTnxReference365DaysRun, &
+                      SetTmaxTnxReference365DaysRun_i, &
+                      SetTmaxTnxReference365DaysRun, &
+                      GetTminTnxReference365DaysRun_i, &
+                      GetTminTnxReference365DaysRun, &
+                      GetTmaxTnxReference365DaysRun_i, &
+                      GetTmaxTnxReference365DaysRun, &
+                      GetTnxReferenceYear, &
+                      SetTnxReferenceYear, &
+                      GetTnxReferenceFile, &
+                      SetTnxReferenceFile, &
+                      GetTnxReferenceFileFull, &
+                      SetTnxReferenceFileFull, &
+                      TminTnxReference365DaysRun, &
+                      TmaxTnxReference365DaysRun, &
+                      TminCropReferenceRun, &
+                      TmaxCropReferenceRun
 
-use ac_kinds,  only: dp, &
+use ac_kinds,  only: sp,&
+                     dp, &
                      int8, &
                      int16, &
                      int32, &
                      intEnum
 use ac_project_input, only: ProjectInput
-use ac_utils, only: roundc
+use ac_utils, only: roundc, &
+                    write_file, &
+                    open_file
 use iso_fortran_env, only: iostat_end
 implicit none
 
 
 logical :: TemperatureFilefull_exists
 real(dp), dimension(:), allocatable :: Tmin, Tmax  !! (daily) temperature data
+type(rep_DayEventDbl), dimension(31) :: TminDataSet, TmaxDataSet
 
 
 contains
@@ -312,6 +355,78 @@ subroutine AdjustDecadeMONTHandYEAR(DecFile, Mfile, Yfile)
     end if
 end subroutine AdjustDecadeMONTHandYEAR
 
+
+!subroutine ReadTnxReference365DaysFilefull()
+!    !! Reads the contents of the TnxReference365DaysFilefull file,
+!    !! storing the temperatures in the TminTnxReference365Days and TmaxTnxReference365Days arrays.
+!
+!    character(len=:), allocatable :: filename
+!    integer :: fhandle, i, nlines, nrows, rc
+!
+!    filename = trim(GetPathNameSimul()) // 'TnxReference365Days.SIM'
+!    open(newunit=fhandle, file=trim(filename), status='old', action='read')
+!
+!    ! Count the number of lines
+!    nlines = 0
+!    do
+!        read(fhandle, '(a)', iostat=rc)
+!        if (rc == iostat_end) then
+!            exit
+!        else
+!            nlines = nlines + 1
+!        end if
+!    end do
+!
+!    ! Now read in the actual content
+!    nrows = nlines - 8
+!    if (allocated(TminTnxReference365DaysRun)) deallocate(TminTnxReference365DaysRun)
+!    if (allocated(TminTnxReference365DaysRun)) deallocate(TmaxTnxReference365DaysRun)
+!    allocate(TminTnxReference365DaysRun(nrows), TmaxTnxReference365DaysRun(nrows))
+!
+!    rewind(fhandle)
+!    do i = 1, nrows
+!        read(fhandle, *) TminTnxReference365DaysRun(i), TmaxTnxReference365DaysRun(i)
+!    end do
+!
+!    close(fhandle)
+!end subroutine ReadTnxReference365DaysFilefull
+
+!
+!subroutine ReadTCropReferenceFilefull()
+!    !! Reads the contents of the TCropReferenceFilefull file,
+!    !! storing the temperatures in the TminCropReference and TmaxCropReference arrays.
+!
+!    character(len=:), allocatable :: filename
+!    integer :: fhandle, i, nlines, nrows, rc
+!
+!    filename = trim(GetPathNameSimul()) // 'TCropReference.SIM'
+!    open(newunit=fhandle, file=trim(filename), status='old', action='read')
+!
+!    ! Count the number of lines
+!    nlines = 0
+!    do
+!        read(fhandle, '(a)', iostat=rc)
+!        if (rc == iostat_end) then
+!            exit
+!        else
+!            nlines = nlines + 1
+!        end if
+!    end do
+!
+!    ! Now read in the actual content
+!    nrows = nlines - 8
+!    if (allocated(TminCropReference)) deallocate(TminCropReference)
+!    if (allocated(TminCropReference)) deallocate(TmaxCropReference)
+!    allocate(TminCropReference(nrows), TmaxCropReference(nrows))
+!
+!    rewind(fhandle)
+!    do i = 1, nrows
+!        read(fhandle, *) TminCropReference(i), TmaxCropReference(i)
+!    end do
+!
+!    close(fhandle)
+!end subroutine ReadTCropReferenceFilefull
+!
 
 subroutine ReadTemperatureFilefull()
     !! Reads the contents of the TemperatureFilefull file,
@@ -1634,8 +1749,8 @@ subroutine GDDCDCToCDC(PlantDayNr, D123, GDDL123, &
     real(dp), intent(in) :: GDDCDC
     real(dp), intent(in) :: Tbase
     real(dp), intent(in) :: Tupper
-    real(dp), intent(inout) :: NoTempFileTMin
-    real(dp), intent(inout) :: NoTempFileTMax
+    real(dp), intent(in) :: NoTempFileTMin
+    real(dp), intent(in) :: NoTempFileTMax
     real(dp), intent(inout) :: CDC
 
     integer(int32) :: ti, GDDi
@@ -2023,7 +2138,7 @@ subroutine LoadSimulationRunProject(NrRun)
     character(len=1025) :: TemperatureDescriptionLocal
 
     real(dp) :: TotDepth
-    integer(int8)  :: FertStress
+    integer(int32)  :: FertStress
     type(rep_clim) :: temperature_record
     integer(int8)  :: RedCGC_temp, RedCCX_temp
     type(CompartmentIndividual), dimension(max_No_compartments) :: &
@@ -2086,6 +2201,10 @@ subroutine LoadSimulationRunProject(NrRun)
         call CompleteClimateDescription(temperature_record)
         call SetTemperatureRecord(temperature_record)
     end if
+
+    ! Create Temperature Reference file 
+    call CreateTnxReferenceFile(GetTemperatureFile(),GetTnxReferenceFile(),GetTnxReferenceYear());
+    call CreateTnxReference365Days();
 
     ! 1.2 ETo
     call SetEToFile(ProjectInput(NrRun)%ETo_Filename)
@@ -2684,7 +2803,7 @@ real(dp) function Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
             TDayMin, TDayMax, GDtranspLow, RatDGDD, SumKcTop, &
             StressInPercent, StrResRedCGC, StrResRedCCx, StrResRedWP, &
             StrResRedKsSto, WeedStress, DeltaWeedStress, StrResCDecline, &
-            ShapeFweed, TheModeCycle, FertilityStressOn, TestRecord)
+            ShapeFweed, TheModeCycle, FertilityStressOn, ReferenceClimate)
      integer(int32), intent(in) :: TheDaysToCCini
      integer(int32), intent(in) :: TheGDDaysToCCini
      integer(int32), intent(in) :: L0
@@ -2719,7 +2838,7 @@ real(dp) function Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
      real(dp), intent(in) :: GDtranspLow
      real(dp), intent(in) :: RatDGDD
      real(dp), intent(in) :: SumKcTop
-     integer(int8), intent(in) :: StressInPercent
+     integer(int32), intent(in) :: StressInPercent
      integer(int8), intent(in) :: StrResRedCGC
      integer(int8), intent(in) :: StrResRedCCx
      integer(int8), intent(in) :: StrResRedWP
@@ -2730,12 +2849,12 @@ real(dp) function Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
      real(dp), intent(in) :: ShapeFweed
      integer(intEnum), intent(in) :: TheModeCycle
      logical, intent(in) :: FertilityStressOn
-     logical, intent(in) :: TestRecord
+     logical, intent(in) :: ReferenceClimate
 
      real(dp), parameter :: EToStandard = 5._dp
      integer(int32), parameter :: k = 2
 
-     integer(int32) ::  fTemp, fOUT, rc
+     integer(int32) ::  fTemp, rc
      real(dp) :: SumGDD, Tndayi, Txdayi, GDDi, CCi,&
                  CCxWitheredForB, TpotForB, EpotTotForB, SumKCi,&
                  fSwitch, WPi, SumBnor, SumKcTopSF, fCCx
@@ -2764,27 +2883,21 @@ real(dp) function Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
          GDDCDCadj = GDDCDC
      end if
 
-     ! TEST
-     if (TestRecord .eqv. .true.) then
-         open(newunit=fOUT, file=trim(GetPathNameSimul()//'TestBio.SIM'), &
-              action='write', status='replace')
-     end if
-
      ! 2. Open Temperature file
      if ((GetTemperatureFile() /= '(None)') .and. &
          (GetTemperatureFile() /= '(External)')) then
-         open(newunit=fTemp, file=trim(GetPathNameSimul()//'TCrop.SIM'), &
-                      status='old', action='read', iostat=rc)
+        if (ReferenceClimate .eqv. .true.) then
+            open(newunit=fTemp, file=trim(GetPathNameSimul()//'TCropReference.SIM'), &
+                 status='old', action='read', iostat=rc)
+        else
+            open(newunit=fTemp, file=trim(GetPathNameSimul()//'TCrop.SIM'), &
+                 status='old', action='read', iostat=rc)
+        end if
      end if
 
      ! 3. Initialize
      SumKcTopSF = (1._dp - real(StressInPercent, kind=dp)/100._dp) * SumKcTop
      !! only required for soil fertility stress
-
-     ! test
-     if (TestRecord .eqv. .true.) then
-        write(fOUT, '(f10.1)') SumKcTopSF
-     end if
 
      call SetSimulation_DelayedDays(0) ! required for CalculateETpot
      SumKci = 0._dp
@@ -2853,9 +2966,13 @@ real(dp) function Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
              GDDi = DegreesDay(Tbase, Tupper, Tndayi, Txdayi, &
                                     GetSimulParam_GDDMethod())
          else
-             read(fTemp, *, iostat=rc) Tndayi, Txdayi
-             GDDi = DegreesDay(Tbase, Tupper, Tndayi, Txdayi,&
-                               GetSimulParam_GDDMethod())
+            read(fTemp, *, iostat=rc) Tndayi, Txdayi
+            if ((rc == iostat_end) .and. (ReferenceClimate .eqv. .true.)) then
+                rewind(fTemp)
+                read(fTemp, *, iostat=rc) Tndayi, Txdayi
+            end if
+            GDDi = DegreesDay(Tbase, Tupper, Tndayi, Txdayi,&
+                              GetSimulParam_GDDMethod())
          end if
          if (TheModeCycle == modeCycle_GDDays) then
              SumGDD = SumGDD + GDDi
@@ -3027,12 +3144,6 @@ real(dp) function Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
                            (TpotForB/EToStandard) ! for salinity stress
          end if
 
-         ! test
-         if (TestRecord .eqv. .true.) then
-             write(fOUT,'(i10, 2f10.1, 3f10.2, f10.1)') &
-                     Dayi, (100._dp*CCi), (100._dp*CCw), &
-                     WeedCorrection, TpotForB, WPi, SumKci
-         end if
      enddo
 
      ! 4. Close Temperature file
@@ -3041,558 +3152,680 @@ real(dp) function Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
          close(fTemp)
      end if
 
-     if (TestRecord .eqv. .true.) then
-         close(fOUT)
-     end if
-
      ! 5. Export
      Bnormalized = SumBnor
 end function Bnormalized
 
 
-real(dp) function BiomassRatio(TempDaysToCCini, TempGDDaysToCCini,&
-           TempCCo, TempCGC, TempCCx, TempCDC, TempGDDCGC, &
-           TempGDDCDC, TempdHIdt, TempL0, TempL12, L12SF,&
-           TempL123, TempHarvest, TempFlower, TempGDDL0, &
-           GDDL12SF, TempGDDL12, TempGDDL123, TempGDDHarvest,&
-           TempHI, TempWPy, TempKc, TempKcDecline, TempCCeffect,&
-           TempTbase, TempTupper, TempTmin, TempTmax, TempGDtranspLow,&
-           TempWP, ShapeFweed, TempModeCycle, SFInfo, SFInfoStress,&
-           WeedStress, DeltaWeedStress, DeterminantCropType, FertilityStressOn)
-    integer(int32), intent(in) :: TempDaysToCCini
-    integer(int32), intent(in) :: TempGDDaysToCCini
-    real(dp), intent(in) :: TempCCo
-    real(dp), intent(in) :: TempCGC
-    real(dp), intent(in) :: TempCCx
-    real(dp), intent(in) :: TempCDC
-    real(dp), intent(in) :: TempGDDCGC
-    real(dp), intent(in) :: TempGDDCDC
-    real(dp), intent(in) :: TempdHIdt
-    integer(int32), intent(in) :: TempL0
-    integer(int32), intent(in) :: TempL12
-    integer(int32), intent(in) :: L12SF
-    integer(int32), intent(in) :: TempL123
-    integer(int32), intent(in) :: TempHarvest
-    integer(int32), intent(in) :: TempFlower
-    integer(int32), intent(in) :: TempGDDL0
-    integer(int32), intent(in) :: GDDL12SF
-    integer(int32), intent(in) :: TempGDDL12
-    integer(int32), intent(in) :: TempGDDL123
-    integer(int32), intent(in) :: TempGDDHarvest
-    integer(int32), intent(in) :: TempHI
-    integer(int32), intent(in) :: TempWPy
-    real(dp), intent(in) :: TempKc
-    real(dp), intent(in) :: TempKcDecline
-    real(dp), intent(in) :: TempCCeffect
-    real(dp), intent(in) :: TempTbase
-    real(dp), intent(in) :: TempTupper
-    real(dp), intent(in) :: TempTmin
-    real(dp), intent(in) :: TempTmax
-    real(dp), intent(in) :: TempGDtranspLow
-    real(dp), intent(in) :: TempWP
-    real(dp), intent(in) :: ShapeFweed
-    integer(intEnum), intent(in) :: TempModeCycle
-    type(rep_EffectStress), intent(in) :: SFInfo
-    integer(int8), intent(in) :: SFInfoStress
-    integer(int8), intent(in) :: WeedStress
-    integer(int32), intent(in) :: DeltaWeedStress
-    logical, intent(in) :: DeterminantCropType
-    logical, intent(in) :: FertilityStressOn
 
-    real(dp), parameter :: CO2iLocal = 369.41_dp
+subroutine CreateTnxReference365Days()
 
-    real(dp) :: SumKcTop, HIGC, HIGClinear
-    real(dp) :: RatDGDD, SumBPot, SumBSF
-    integer(int32) :: tSwitch, DaysYieldFormation
+    character(len=:), allocatable :: totalnameOUT
+    character(len=1025) :: TempString
+    integer(int32) :: DayNri
+    integer(int32) :: i, Monthi
+    type(rep_DayEventDbl), dimension(31) :: TminDataSet_temp,TmaxDataSet_temp
+    real(dp) :: Tlow, Thigh
 
-    ! 1. Initialize
-    ! 1 - a. Maximum sum Kc
-    SumKcTop = SeasonalSumOfKcPot(TempDaysToCCini, TempGDDaysToCCini,&
-        TempL0, TempL12, TempL123, TempHarvest, TempGDDL0, TempGDDL12,&
-        TempGDDL123, TempGDDHarvest, TempCCo, TempCCx, TempCGC,&
-        TempGDDCGC, TempCDC, TempGDDCDC, TempKc, TempKcDecline, TempCCeffect,&
-        TempTbase, TempTupper, TempTmin, TempTmax, TempGDtranspLow, CO2iLocal,&
-        TempModeCycle)
-    ! 1 - b. Prepare for growing degree days
-    RatDGDD = 1._dp
-    if ((TempModeCycle == modeCycle_GDDays) .and. (SFInfoStress > 0_int8) &
-        .and. (GDDL12SF < TempGDDL123)) then
-        RatDGDD = (TempL123-L12SF)/real(TempGDDL123-GDDL12SF, kind=dp)
+    if (FileExists(GetTnxReferenceFileFull())) then
+        ! create SIM file
+        totalnameOUT = trim(GetPathNameSimul()) // 'TnxReference365Days.SIM'
+        call fTnxReference365Days_open(totalnameOUT, 'w')
+        
+        ! get data set for 1st month
+        Monthi = 1
+        call GetMonthlyTemperatureDataSetFromTnxReferenceFile(Monthi, TminDataSet_temp, TmaxDataSet_temp)
+        !WRITE(*, '(A, 2f10.2)') 'TminDataSet_temp(1)%Param: ', TminDataSet_temp(1)%Param
+        !WRITE(*, '(A, 2f10.2)') 'TmaxDataSet_temp(1)%Param: ', TmaxDataSet_temp(1)%Param
+        
+        ! Tnx for Day 1 to 365
+        do DayNri = 1, 365
+            !WRITE(*, '(A, i4)') 'TminDataSet_temp(31)%DayNr', TminDataSet_temp(31)%DayNr
+            !WRITE(*, '(A, i4)') 'DayNri', DayNri
+            if (DayNri > TminDataSet_temp(31)%DayNr) then
+                ! next month
+                Monthi = Monthi + 1
+                !WRITE(*, '(A, i4)') 'next month', Monthi
+                call GetMonthlyTemperatureDataSetFromTnxReferenceFile(Monthi, TminDataSet_temp, TmaxDataSet_temp)
+            end if
+            i = 1
+            !WRITE(*, '(A,i4)') 'DayNri', DayNri
+            do while (TminDataSet_temp(i)%DayNr /= DayNri)
+                !WRITE(*, '(i4)') i
+                !WRITE(*, '(i4)') TminDataSet_temp(i)%DayNr
+                !WRITE(*, '(i4)') DayNri
+                i = i+1
+            end do
+            Tlow = real(roundc(100*TminDataSet_temp(i)%Param, mold=int32),kind=dp)/100._dp
+            Thigh = real(roundc(100*TmaxDataSet_temp(i)%Param, mold=int32),kind=dp)/100._dp
+            write(TempString, '(2f10.2)') Tlow, Thigh
+            call SetTminTnxReference365DaysRun_i(DayNri,Tlow)
+            call SetTmaxTnxReference365DaysRun_i(DayNri,Thigh)
+            call fTnxReference365Days_write(trim(TempString))
+        end do
+        ! Close file
+        call fTnxReference365Days_close()
     end if
-    ! 1 - c. Get PercentLagPhase (for estimate WPi during yield formation)
-    DaysYieldFormation = undef_int
-    if ((GetCrop_subkind() == subkind_Tuber) .or. &
-        (GetCrop_subkind() == subkind_Grain)) then
-        ! DaysToFlowering corresponds with Tuberformation
-        DaysYieldFormation = roundc(TempHI/TempdHIdt, mold=1)
-        if (DeterminantCropType) then
-            HIGC = HarvestIndexGrowthCoefficient(real(TempHI,kind=dp), TempdHIdt)
-            call GetDaySwitchToLinear(TempHI, TempdHIdt, &
-                     HIGC, tSwitch, HIGClinear)
-        else
-            tSwitch = roundc(DaysYieldFormation/3._dp, mold=1)
-        end if
+end subroutine CreateTnxReference365Days
+
+
+subroutine CreateTnxReferenceFile(TemperatureFile, TnxReferenceFile, TnxReferenceYear)
+    character(len=*), intent(in) :: TemperatureFile
+    character(len=*), intent(in) :: TnxReferenceFile
+    integer(int32), intent(in) :: TnxReferenceYear
+
+    real(dp), dimension(12) :: MonthVal1, MonthVal2
+    character(len=:), allocatable :: FullName
+    integer(int32)   :: fhandle, rc
+    integer(int32) :: i, NrYears
+    integer(int32) :: Yeari, Monthi, MonthDays, MonthDecs, Deci, Dayi
+    real(dp) :: SUM1, SUM2, Val1, Val2
+    integer(int32) :: DayNri, EndDayNr
+    logical :: EndMonth
+    integer(int32), dimension(12) :: MonthNrYears
+    character(len=:), allocatable :: TempString
+    character(len=1025) :: TempString2
+
+    ! 1a. Delete existing TnxReferenceFile and adjust TnxReferenceYear
+    FullName = trim(GetPathNameSimul()) // TnxReferenceFile
+    if (FileExists(FullName)) then
+        call unlink(FullName)
+        call SetTnxReferenceYear(2000)
     end if
-
-    ! 2. potential biomass - no soil fertiltiy stress - no weed stress
-    SumBPot = Bnormalized(TempDaysToCCini, TempGDDaysToCCini,&
-        TempL0, TempL12, TempL12, TempL123, TempHarvest, TempFlower,&
-        TempGDDL0, TempGDDL12, TempGDDL12, TempGDDL123, TempGDDHarvest,&
-        TempWPy, DaysYieldFormation, tSwitch,&
-        TempCCo, TempCCx, TempCGC, TempGDDCGC, TempCDC, TempGDDCDC,&
-        TempKc, TempKcDecline, TempCCeffect, TempWP, CO2iLocal,&
-        TempTbase, TempTupper, TempTmin, TempTmax, TempGDtranspLow, 1._dp,&
-        SumKcTop, 0_int8, 0_int8, 0_int8, 0_int8, 0_int8, 0_int8,&
-        0, 0._dp, -0.01_dp, &
-        TempModeCycle, FertilityStressOn, .false.)
-
-    ! 3. potential biomass - soil fertiltiy stress and weed stress
-    SumBSF = Bnormalized(TempDaysToCCini, TempGDDaysToCCini,&
-        TempL0, TempL12, L12SF, TempL123, TempHarvest, TempFlower,&
-        TempGDDL0, TempGDDL12, GDDL12SF, TempGDDL123, TempGDDHarvest, &
-        TempWPy, DaysYieldFormation, tSwitch,&
-        TempCCo, TempCCx, TempCGC, TempGDDCGC, TempCDC, TempGDDCDC,&
-        TempKc, TempKcDecline, TempCCeffect, TempWP, CO2iLocal,&
-        TempTbase, TempTupper, TempTmin, TempTmax, TempGDtranspLow, RatDGDD,&
-        SumKcTop, SFInfoStress, SFInfo%RedCGC, SFInfo%RedCCX, SFInfo%RedWP,&
-        SFInfo%RedKsSto, WeedStress, DeltaWeedStress, &
-        SFInfo%CDecline, ShapeFweed, TempModeCycle, &
-        FertilityStressOn, .false.)
-
-    BiomassRatio = SumBSF/SumBPot
-end function BiomassRatio
-
-
-subroutine StressBiomassRelationship(TheDaysToCCini, TheGDDaysToCCini,&
-            L0, L12, L123, L1234, LFlor, LengthFlor, GDDL0, GDDL12,&
-            GDDL123, GDDL1234, WPyield, RefHI, CCo, CCx, CGC, GDDCGC,&
-            CDC, GDDCDC, KcTop, KcDeclAgeing, CCeffectProcent,&
-            Tbase, Tupper, TDayMin, TDayMax, GDtranspLow, WPveg, RatedHIdt,&
-            CO2Given, CropDNr1, CropDeterm, CropSResp, TheCropType,&
-            TheModeCycle, b0, b1, b2, &
-            BM10, BM20, BM30, BM40, BM50, BM60, BM70)
-    integer(int32), intent(in) :: TheDaysToCCini
-    integer(int32), intent(in) :: TheGDDaysToCCini
-    integer(int32), intent(in) :: L0
-    integer(int32), intent(in) :: L12
-    integer(int32), intent(in) :: L123
-    integer(int32), intent(in) :: L1234
-    integer(int32), intent(in) :: LFlor
-    integer(int32), intent(in) :: LengthFlor
-    integer(int32), intent(in) :: GDDL0
-    integer(int32), intent(in) :: GDDL12
-    integer(int32), intent(in) :: GDDL123
-    integer(int32), intent(in) :: GDDL1234
-    integer(int32), intent(in) :: WPyield
-    integer(int32), intent(in) :: RefHI
-    real(dp), intent(in) :: CCo
-    real(dp), intent(in) :: CCx
-    real(dp), intent(in) :: CGC
-    real(dp), intent(in) :: GDDCGC
-    real(dp), intent(in) :: CDC
-    real(dp), intent(in) :: GDDCDC
-    real(dp), intent(in) :: KcTop
-    real(dp), intent(in) :: KcDeclAgeing
-    real(dp), intent(in) :: CCeffectProcent
-    real(dp), intent(in) :: Tbase
-    real(dp), intent(in) :: Tupper
-    real(dp), intent(in) :: TDayMin
-    real(dp), intent(in) :: TDayMax
-    real(dp), intent(in) :: GDtranspLow
-    real(dp), intent(in) :: WPveg
-    real(dp), intent(in) :: RatedHIdt
-    real(dp), intent(in) :: CO2Given
-    integer(int32), intent(in) :: CropDNr1
-    logical, intent(in) :: CropDeterm
-    type(rep_Shapes), intent(in) :: CropSResp
-    integer(intEnum), intent(in) :: TheCropType
-    integer(intEnum), intent(in) :: TheModeCycle
-    real(dp), intent(inout) :: b0
-    real(dp), intent(inout) :: b1
-    real(dp), intent(inout) :: b2
-    real(dp), intent(inout) :: BM10
-    real(dp), intent(inout) :: BM20
-    real(dp), intent(inout) :: BM30
-    real(dp), intent(inout) :: BM40
-    real(dp), intent(inout) :: BM50
-    real(dp), intent(inout) :: BM60
-    real(dp), intent(inout) :: BM70
-
-    type StressIndexes
-        integer(int8) :: StressProc
-            !! Undocumented
-        real(dp) :: BioMProc
-            !! Undocumented
-        real(dp) :: BioMSquare
-            !! Undocumented
-    end type StressIndexes
-
-    type(StressIndexes), dimension(8) :: StressMatrix
-    integer(int8) :: Si
-    integer(int32) :: L12SF, GDDL12SF
-    type(rep_EffectStress) :: StressResponse
-    real(dp) :: RatDGDD, BNor, BNor100, Yavg, X1avg, X2avg,&
-                y, x1, x2, x1y, x2y, x1Sq, x2Sq, x1x2, &
-                SUMx1y, SUMx2y, SUMx1Sq, SUMx2Sq, SUMx1x2
-    integer(int8) :: SiPr
-    real(dp) :: SumKcTop, HIGC, HIGClinear
-    integer(int32) :: DaysYieldFormation, tSwitch
-    real(dp) :: TDayMax_temp, TDayMin_temp
-
-    ! 1. initialize
-    call SetSimulation_DelayedDays(0) ! required for CalculateETpot
-    L12SF = L12 ! to calculate SumKcTop (no stress)
-    GDDL12SF = GDDL12 ! to calculate SumKcTop (no stress)
-    ! Maximum sum Kc (no stress)
-    SumKcTop = SeasonalSumOfKcPot(TheDaysToCCini, TheGDDaysToCCini,&
-        L0, L12, L123, L1234, GDDL0, GDDL12, GDDL123, GDDL1234,&
-        CCo, CCx, CGC, GDDCGC, CDC, GDDCDC, KcTop, KcDeclAgeing,&
-        CCeffectProcent, Tbase, Tupper, TDayMin, TDayMax, &
-        GDtranspLow, CO2Given, TheModeCycle)
-
-    ! Get PercentLagPhase (for estimate WPi during yield formation)
-    if ((TheCropType == subkind_Tuber) .or. (TheCropType == subkind_grain)) then
-        ! DaysToFlowering corresponds with Tuberformation
-        DaysYieldFormation = roundc(RefHI/RatedHIdt, mold=1)
-        if (CropDeterm) then
-            HIGC = HarvestIndexGrowthCoefficient(real(RefHI, kind=dp), RatedHIdt)
-            call GetDaySwitchToLinear(RefHI, RatedHIdt, HIGC, tSwitch,&
-                  HIGClinear)
-        else
-            tSwitch = roundc(DaysYieldFormation/3._dp, mold=1)
-        end if
+    ! 1b. Delete existing TnxReference365Days.SIM
+    FullName = trim(GetPathNameSimul()) // 'TnxReference365Days.SIM'
+    if (FileExists(FullName)) then
+        call unlink(FullName)
+    end if
+    ! 1c. Delete existing TCropReference.SIM
+    FullName = trim(GetPathNameSimul()) // 'TCropReference.SIM'
+    if (FileExists(FullName)) then
+        call unlink(FullName)
     end if
 
-    ! 2. Biomass production for various stress levels
-    do Si = 1, 8
-        ! various stress levels
-        ! stress effect
-        SiPr = int(10*(Si-1), kind=int8)
-        StressMatrix(Si)%StressProc = SiPr
-        call CropStressParametersSoilFertility(CropSResp, SiPr, StressResponse)
-        ! adjusted length of Max canopy cover
-        RatDGDD = 1
-        if ((StressResponse%RedCCX == 0) .and. &
-            (StressResponse%RedCGC == 0))then
-            L12SF = L12
-            GDDL12SF = GDDL12
-        else
-            call TimeToMaxCanopySF(CCo, CGC, CCx, L0, L12, L123, LFlor,&
-                   LengthFlor, CropDeterm, L12SF, StressResponse%RedCGC,&
-                   StressResponse%RedCCX, SiPr)
-            if (TheModeCycle == modeCycle_GDDays) then
-                TDayMin_temp = TDayMin
-                TDayMax_temp = TDayMax
-                GDDL12SF = GrowingDegreeDays(L12SF, CropDNr1, Tbase, Tupper,&
-                                 TDayMin_temp, TDayMax_temp)
+
+    ! 2. Get Mean monthly data
+    if (TemperatureFile /= '(None)') then
+        ! 2.a Preparation
+        ! Get Number of Years
+        NrYears = GetTemperatureRecord_ToY() - GetTemperatureRecord_FromY() + 1
+        !WRITE(*, '(A, i4)') 'The value of NrYears is:', NrYears
+        ! Get TnxReferenceYear
+        call SetTnxReferenceYear(roundc((GetTemperatureRecord_FromY()+GetTemperatureRecord_ToY())/2._dp,mold=1_int32))
+        if (GetTnxReferenceYear() == 1901) then
+            call SetTnxReferenceYear(2000)
+        end if
+        ! check number of years for each month
+        do Monthi = 1, 12
+            MonthNrYears(Monthi) = NrYears
+        end do
+        if (NrYears > 1) then
+            if (GetTemperatureRecord_FromM() > 1) then
+                do Monthi = 1, (GetTemperatureRecord_FromM()-1)
+                    MonthNrYears(Monthi) = MonthNrYears(Monthi) - 1
+                end do
             end if
-            if ((TheModeCycle == modeCycle_GDDays) .and. (GDDL12SF < GDDL123)) then
-                RatDGDD = (L123-L12SF)*1._dp/(GDDL123-GDDL12SF)
+            if (GetTemperatureRecord_ToM() < 12) then
+                do Monthi = 12, (GetTemperatureRecord_ToM()+1), -1
+                    MonthNrYears(Monthi) = MonthNrYears(Monthi) - 1
+                end do
             end if
         end if
-        ! biomass production
-        BNor = Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
-                L0, L12, L12SF, L123, L1234, LFlor,&
-                GDDL0, GDDL12, GDDL12SF, GDDL123, GDDL1234, WPyield, &
-                DaysYieldFormation, tSwitch, CCo, CCx, CGC, GDDCGC, CDC,&
-                GDDCDC, KcTop, KcDeclAgeing, CCeffectProcent, WPveg, CO2Given,&
-                Tbase, Tupper, TDayMin, TDayMax, GDtranspLow, RatDGDD,&
-                SumKcTop, SiPr, StressResponse%RedCGC, StressResponse%RedCCX,&
-                StressResponse%RedWP, StressResponse%RedKsSto, 0_int8, 0 ,&
-                StressResponse%CDecline, -0.01_dp, TheModeCycle, .true.,&
-                .false.)
-        if (Si == 1) then
-            BNor100 = BNor
-            StressMatrix(1)%BioMProc = 100._dp
-        else
-            if (BNor100 > 0.00001_dp) then
-                StressMatrix(Si)%BioMProc = 100._dp * BNor/BNor100
-            else
-                StressMatrix(Si)%BioMProc = 100._dp
+                
+        ! initialize
+        do Monthi = 1, 12
+            MonthVal1(Monthi) = 0._dp ! Tmin data
+            MonthVal2(Monthi) = 0._dp ! Tmax data
+        end do
+        Yeari = GetTemperatureRecord_FromY()
+        Monthi = GetTemperatureRecord_FromM()
+        DayNri = GetTemperatureRecord_FromDayNr()
+        EndMonth = .false.
+        EndDayNr = undef_int
+        Deci = undef_int
+        SUM1 = 0._dp
+        SUM2 = 0._dp
+        MonthDays = 0
+        MonthDecs = 0
+        select case (GetTemperatureRecord_DataType())
+        case (datatype_daily)
+            ! EndDayNr = DayNr of last day in month
+            Dayi = DaysInMonth(Monthi)
+            if ((LeapYear(Yeari) .eqv. .true.) .and. (Monthi == 2)) then
+                Dayi = Dayi + 1
             end if
-        end if
-        StressMatrix(Si)%BioMSquare =&
-             StressMatrix(Si)%BioMProc *&
-             StressMatrix(Si)%BioMProc
-        ! end stress level
-    end do
+            call DetermineDayNr(Dayi, Monthi, Yeari, EndDayNr)
+        end select
+            
+        ! open temperature file
+        open(newunit=fhandle, file=trim(GetTemperatureFilefull()), &
+                     status='old', action='read', iostat=rc)
+        read(fhandle, *, iostat=rc) ! Description
+        read(fhandle, *, iostat=rc) ! Data type
+        read(fhandle, *, iostat=rc) ! Day
+        read(fhandle, *, iostat=rc) ! Month
+        read(fhandle, *, iostat=rc) ! Year
+        read(fhandle, *, iostat=rc) ! Title
+        read(fhandle, *, iostat=rc) ! Title
+        read(fhandle, *, iostat=rc) ! Title
 
-    ! 5. Stress - Biomass relationship
-    Yavg = 0._dp
-    X1avg = 0._dp
-    X2avg = 0._dp
-    do Si = 1, 8
-        ! various stress levels
-        Yavg = Yavg + StressMatrix(Si)%StressProc
-        X1avg = X1avg + StressMatrix(Si)%BioMProc
-        X2avg = X2avg + StressMatrix(Si)%BioMSquare
-    end do
-    Yavg  = Yavg/8._dp
-    X1avg = X1avg/8._dp
-    X2avg = X2avg/8._dp
-    SUMx1y  = 0._dp
-    SUMx2y  = 0._dp
-    SUMx1Sq = 0._dp
-    SUMx2Sq = 0._dp
-    SUMx1x2 = 0._dp
-    do Si = 1, 8
-        ! various stress levels
-        y     = StressMatrix(Si)%StressProc - Yavg
-        x1    = StressMatrix(Si)%BioMProc - X1avg
-        x2    = StressMatrix(Si)%BioMSquare - X2avg
-        x1y   = x1 * y
-        x2y   = x2 * y
-        x1Sq  = x1 * x1
-        x2Sq  = x2 * x2
-        x1x2  = x1 * x2
-        SUMx1y  = SUMx1y + x1y
-        SUMx2y  = SUMx2y + x2y
-        SUMx1Sq = SUMx1Sq + x1Sq
-        SUMx2Sq = SUMx2Sq + x2Sq
-        SUMx1x2 = SUMx1x2 + x1x2
-    end do
+        ! 2.b Determine mean monthly data
+        do while (rc /= iostat_end)
+            ! read data
+            read(fhandle, *, iostat=rc) Val1, Val2 ! Tmin, Tmax
+            if (rc == iostat_end) exit
+            !WRITE(*, '(A, f10.2)') 'The value of Val1 is:', Val1
+            !WRITE(*, '(A, f10.2)') 'The value of Val2 is:', Val2
+            SUM1 = SUM1 + Val1 ! minimum temperature
+            SUM2 = SUM2 + Val2 ! maximum temperature
+            ! check end of month
+            select case (GetTemperatureRecord_DataType())
+            case (datatype_daily)
+                MonthDays = MonthDays + 1
+                if (DayNri == EndDayNr) then
+                    EndMonth = .true.
+                end if
+            case (datatype_decadely)
+                MonthDecs = MonthDecs + 1
+                if (Deci == 3) then
+                    EndMonth = .true.
+                end if
+            case (datatype_monthly)
+                EndMonth = .true.
+            end select
+            if (rc == iostat_end) then
+                EndMonth = .true.
+            end if
+            ! End of Month
+            if (EndMonth .eqv. .true.) then
+                ! mean monthly values Tmin and Tmax
+                select case (GetTemperatureRecord_DataType())
+                case (datatype_daily)
+            !WRITE(*, '(A, f10.2)') 'The value of SUM1 is:', SUM1
+            !WRITE(*, '(A, f10.2)') 'The value of SUM2 is:', SUM2
+            !WRITE(*, '(A, I4)') 'The value of MonthDays is:', MonthDays
+                    SUM1 = SUM1/real(MonthDays, kind=dp)
+                    SUM2 = SUM2/real(MonthDays, kind=dp)
+                case (datatype_decadely)
+                    SUM1 = SUM1/real(MonthDecs, kind=dp)
+                    SUM2 = SUM2/real(MonthDecs, kind=dp)
+                end select
+                MonthVal1(Monthi) = MonthVal1(Monthi) + SUM1/real(MonthNrYears(Monthi),kind=dp) ! Tmin
+                MonthVal2(Monthi) = MonthVal2(Monthi) + SUM2/real(MonthNrYears(Monthi),kind=dp) ! Tmax
+                !WRITE(*, '(A, i4)') 'The value of Monthi is:', Monthi
+                !WRITE(*, '(A, f10.4)') 'The value of MonthVal1 is:', MonthVal1(Monthi)
+                !WRITE(*, '(A, f10.4)') 'The value of MonthVal2 is:', MonthVal2(Monthi)
+                ! Next month
+                SUM1 = 0._dp
+                SUM2 = 0._dp
+                if (Monthi == 12) then
+                    Monthi = 1
+                    Yeari = Yeari + 1
+                else
+                    Monthi = Monthi + 1
+                end if
+                EndMonth = .false.
+                select case (GetTemperatureRecord_DataType())
+                case (datatype_daily)
+                    ! EndDayNr = DayNr of last day in month
+                    MonthDays = 0
+                    Dayi = DaysInMonth(Monthi)
+                    if ((LeapYear(Yeari) .eqv. .true.) .and. (Monthi == 2)) then
+                        Dayi = Dayi + 1
+                    end if
+                    call DetermineDayNr(Dayi, Monthi, Yeari, EndDayNr)
+                case (datatype_decadely)
+                    MonthDecs = 0
+                    Deci = 0
+                end select
+            end if
+            ! Next day, decade, month
+            select case (GetTemperatureRecord_DataType())
+            case (datatype_daily)
+                DayNri = DayNri + 1
+            end select
+        end do
+        
+        ! close temperature file
+        close(fhandle)
+    end if
+    ! 3. Create and Save TnxReference File
+    if (TemperatureFile /= '(None)') then
+        ! Determine Name of TnxReference File
+        i = len(trim(TemperatureFile))
+        TempString = trim(TemperatureFile)
+        call SetTnxReferenceFile(TempString(:i-4) // 'Reference.Tnx')
+        FullName = trim(GetPathNameSimul()) // GetTnxReferenceFile()
+        call SetTnxReferenceFileFull(FullName)
+        ! Save mean monhtly data data
+        call fTnxReference_open(FullName, 'w')
+        call fTnxReference_write('Reference : ' // trim(GetTemperatureDescription()))
+        call fTnxReference_write('     3  : Monthly records (1=daily, 2=10-daily and 3=monthly data)')
+        call fTnxReference_write('     1  : First day of record (1, 11 or 21 for 10-day or 1 for months)')
+        call fTnxReference_write('     1  : First month of record')
+        call fTnxReference_write('  1901  : First year of record (1901 if not linked to a specific year)')
+        call fTnxReference_write('')
+        call fTnxReference_write('  Tmin (C)   TMax (C) ')
+        call fTnxReference_write('  =======================')
+        do Monthi = 1, 12
+            write(TempString2, '(2f10.2)') MonthVal1(Monthi), MonthVal2(Monthi)
+            call fTnxReference_write(trim(TempString2))
+            call SetTminTnxReference12MonthsRun_i(Monthi,real(roundc(100*MonthVal1(Monthi),mold=int32),kind=dp)/100._dp)
+            call SetTmaxTnxReference12MonthsRun_i(Monthi,real(roundc(100*MonthVal2(Monthi),mold=int32),kind=dp)/100._dp)
+        end do
+        call fTnxReference_close()
+    end if
+end subroutine CreateTnxReferenceFile
 
-    if (abs(roundc(SUMx1x2*1000._dp, mold=1)) /= 0) then
-        b2 = (SUMx1y - (SUMx2y * SUMx1Sq)/SUMx1x2)/&
-             (SUMx1x2 - (SUMx1Sq * SUMx2Sq)/SUMx1x2)
-        b1 = (SUMx1y - b2 * SUMx1x2)/SUMx1Sq
-        b0 = Yavg - b1*X1avg - b2*X2avg
 
-        BM10 =  StressMatrix(2)%BioMProc
-        BM20 =  StressMatrix(3)%BioMProc
-        BM30 =  StressMatrix(4)%BioMProc
-        BM40 =  StressMatrix(5)%BioMProc
-        BM50 =  StressMatrix(6)%BioMProc
-        BM60 =  StressMatrix(7)%BioMProc
-        BM70 =  StressMatrix(8)%BioMProc
+!TminDatSet
+
+function GetTminDataSet() result(TminDataSet_out)
+    !! Getter for the "TminDataSet" global variable.
+    type(rep_DayEventDbl), dimension(31) :: TminDataSet_out
+
+    TminDataSet_out = TminDataSet
+end function GetTminDataSet
+
+
+function GetTminDataSet_i(i) result(TminDataSet_i)
+    !! Getter for individual elements of the "TminDataSet" global variable.
+    integer(int32), intent(in) :: i
+    type(rep_DayEventDbl) :: TminDataSet_i
+
+    TminDataSet_i = TminDataSet(i)
+end function GetTminDataSet_i
+
+
+integer(int32) function GetTminDataSet_DayNr(i)
+    integer(int32), intent(in) :: i
+
+    GetTminDataSet_DayNr = TminDataSet(i)%DayNr
+end function GetTminDataSet_DayNr
+
+
+real(dp) function GetTminDataSet_Param(i)
+    integer(int32), intent(in) :: i
+
+    GetTminDataSet_Param = TminDataSet(i)%Param
+end function GetTminDataSet_Param
+
+
+subroutine SetTminDataSet(TminDataSet_in)
+    !! Setter for the "TminDatSet" global variable.
+    type(rep_DayEventDbl), dimension(31), intent(in) :: TminDataSet_in
+
+    TminDataSet = TminDataSet_in
+end subroutine SetTminDataSet
+
+
+subroutine SetTminDataSet_i(i, TminDataSet_i)
+    !! Setter for individual element for the "TminDataSet" global variable.
+    integer(int32), intent(in) :: i
+    type(rep_DayEventDbl), intent(in) :: TminDataSet_i
+
+    TminDataSet(i) = TminDataSet_i
+end subroutine SetTminDataSet_i
+
+
+subroutine SetTminDataSet_DayNr(i, DayNr_in)
+    integer(int32), intent(in) :: i
+    integer(int32), intent(in) :: DayNr_in
+
+    TminDataSet(i)%DayNr = DayNr_in
+end subroutine SetTminDataSet_DayNr
+
+
+subroutine SetTminDataSet_Param(i, Param_in)
+    integer(int32), intent(in) :: i
+    real(dp), intent(in) :: Param_in
+
+    TminDataSet(i)%Param = Param_in
+end subroutine SetTminDataSet_Param
+
+! TmaxDataSet
+
+function GetTmaxDataSet() result(TmaxDataSet_out)
+    !! Getter for the "TmaxDataSet" global variable.
+    type(rep_DayEventDbl), dimension(31) :: TmaxDataSet_out
+
+    TmaxDataSet_out = TmaxDataSet
+end function GetTmaxDataSet
+
+
+function GetTmaxDataSet_i(i) result(TmaxDataSet_i)
+    !! Getter for individual elements of the "TmaxDataSet" global variable.
+    integer(int32), intent(in) :: i
+    type(rep_DayEventDbl) :: TmaxDataSet_i
+
+    TmaxDataSet_i = TmaxDataSet(i)
+end function GetTmaxDataSet_i
+
+
+integer(int32) function GetTmaxDataSet_DayNr(i)
+    integer(int32), intent(in) :: i
+
+    GetTmaxDataSet_DayNr = TmaxDataSet(i)%DayNr
+end function GetTmaxDataSet_DayNr
+
+
+real(dp) function GetTmaxDataSet_Param(i)
+    integer(int32), intent(in) :: i
+
+    GetTmaxDataSet_Param = TmaxDataSet(i)%Param
+end function GetTmaxDataSet_Param
+
+
+subroutine SetTmaxDataSet(TmaxDataSet_in)
+    !! Setter for the "TmaxDatSet" global variable.
+    type(rep_DayEventDbl), dimension(31), intent(in) :: TmaxDataSet_in
+
+    TmaxDataSet = TmaxDataSet_in
+end subroutine SetTmaxDataSet
+
+
+subroutine SetTmaxDataSet_i(i, TmaxDataSet_i)
+    !! Setter for individual element for the "TmaxDataSet" global variable.
+    integer(int32), intent(in) :: i
+    type(rep_DayEventDbl), intent(in) :: TmaxDataSet_i
+
+    TmaxDataSet(i) = TmaxDataSet_i
+end subroutine SetTmaxDataSet_i
+
+
+subroutine SetTmaxDataSet_DayNr(i, DayNr_in)
+    integer(int32), intent(in) :: i
+    integer(int32), intent(in) :: DayNr_in
+
+    TmaxDataSet(i)%DayNr = DayNr_in
+end subroutine SetTmaxDataSet_DayNr
+
+
+subroutine SetTmaxDataSet_Param(i, Param_in)
+    integer(int32), intent(in) :: i
+    real(dp), intent(in) :: Param_in
+
+    TmaxDataSet(i)%Param = Param_in
+end subroutine SetTmaxDataSet_Param
+
+
+! fTnxReference
+
+subroutine fTnxReference_open(filename, mode)
+    !! Opens the given file, assigning it to the 'fTnxReference' file handle.
+    character(len=*), intent(in) :: filename
+        !! name of the file to assign the file handle to
+    character, intent(in) :: mode
+        !! open the file for reading ('r'), writing ('w') or appending ('a')
+
+    call open_file(fTnxReference, filename, mode, fTnxReference_iostat)
+end subroutine fTnxReference_open
+
+
+subroutine fTnxReference_write(line, advance_in)
+    !! Writes the given line to the fTnxReference file.
+    character(len=*), intent(in) :: line
+        !! line to write
+    logical, intent(in), optional :: advance_in
+        !! whether or not to append a newline character
+
+    logical :: advance
+
+    if (present(advance_in)) then
+        advance = advance_in
     else
-        b2 = real(undef_int, kind=dp)
-        b1 = real(undef_int, kind=dp)
-        b0 = real(undef_int, kind=dp)
+        advance = .true.
     end if
-end subroutine StressBiomassRelationship
+    call write_file(fTnxReference, line, advance, fTnxReference_iostat)
+end subroutine fTnxReference_write
 
 
-subroutine CCxSaltStressRelationship(TheDaysToCCini, TheGDDaysToCCini,&
-       L0, L12, L123, L1234, LFlor, LengthFlor, GDDFlor, GDDLengthFlor,&
-       GDDL0, GDDL12, GDDL123, GDDL1234, WPyield, RefHI, CCo, CCx, CGC,&
-       GDDCGC, CDC, GDDCDC, KcTop, KcDeclAgeing, CCeffectProcent, Tbase,&
-       Tupper, TDayMin, TDayMax, GDbioLow, WPveg, RatedHIdt, CO2Given,&
-       CropDNr1, CropDeterm, TheCropType, TheModeCycle, TheCCsaltDistortion,&
-       Coeffb0Salt, Coeffb1Salt, Coeffb2Salt, Salt10, Salt20, Salt30,&
-       Salt40, Salt50, Salt60, Salt70, Salt80, Salt90)
-    integer(int32), intent(in) :: TheDaysToCCini
-    integer(int32), intent(in) :: TheGDDaysToCCini
-    integer(int32), intent(in) :: L0
-    integer(int32), intent(in) :: L12
-    integer(int32), intent(in) :: L123
-    integer(int32), intent(in) :: L1234
-    integer(int32), intent(in) :: LFlor
-    integer(int32), intent(in) :: LengthFlor
-    integer(int32), intent(in) :: GDDFlor
-    integer(int32), intent(in) :: GDDLengthFlor
-    integer(int32), intent(in) :: GDDL0
-    integer(int32), intent(in) :: GDDL12
-    integer(int32), intent(in) :: GDDL123
-    integer(int32), intent(in) :: GDDL1234
-    integer(int32), intent(in) :: WPyield
-    integer(int32), intent(in) :: RefHI
-    real(dp), intent(in) :: CCo
-    real(dp), intent(in) :: CCx
-    real(dp), intent(in) :: CGC
-    real(dp), intent(in) :: GDDCGC
-    real(dp), intent(in) :: CDC
-    real(dp), intent(in) :: GDDCDC
-    real(dp), intent(in) :: KcTop
-    real(dp), intent(in) :: KcDeclAgeing
-    real(dp), intent(in) :: CCeffectProcent
-    real(dp), intent(in) :: Tbase
-    real(dp), intent(in) :: Tupper
-    real(dp), intent(in) :: TDayMin
-    real(dp), intent(in) :: TDayMax
-    real(dp), intent(in) :: GDbioLow
-    real(dp), intent(in) :: WPveg
-    real(dp), intent(in) :: RatedHIdt
-    real(dp), intent(in) :: CO2Given
-    integer(int32), intent(in) :: CropDNr1
-    logical, intent(in) :: CropDeterm
-    integer(intEnum), intent(in) :: TheCropType
-    integer(intEnum), intent(in) :: TheModeCycle
-    integer(int8), intent(in) :: TheCCsaltDistortion
-    real(dp), intent(inout) :: Coeffb0Salt
-    real(dp), intent(inout) :: Coeffb1Salt
-    real(dp), intent(inout) :: Coeffb2Salt
-    real(dp), intent(inout) :: Salt10
-    real(dp), intent(inout) :: Salt20
-    real(dp), intent(inout) :: Salt30
-    real(dp), intent(inout) :: Salt40
-    real(dp), intent(inout) :: Salt50
-    real(dp), intent(inout) :: Salt60
-    real(dp), intent(inout) :: Salt70
-    real(dp), intent(inout) :: Salt80
-    real(dp), intent(inout) :: Salt90
+subroutine fTnxReference_close()
+    close(fTnxReference)
+end subroutine fTnxReference_close
 
-    type StressIndexes
-        integer(int8) :: CCxReduction
-            !! Undocumented
-        real(dp) :: SaltProc
-            !! Undocumented
-        real(dp) :: SaltSquare
-            !! Undocumented
-    end type StressIndexes
 
-    integer(int32) :: L12SS, GDDL12SS, DaysYieldFormation, tSwitch
-    real(dp) :: SumKcTop, HIGC, HIGClinear, CCToReach
-    integer(int8) :: Si, SiPr
-    type(StressIndexes), dimension(10) :: StressMatrix
-    type(rep_EffectStress) :: StressResponse
-    real(dp) :: RatDGDD, BNor, BNor100, BioMProc
-    real(dp) :: Yavg, X1avg, X2avg, SUMx1y, SUMx2y, SUMx1Sq, &
-         SUMx2Sq, SUMx1x2, y, x1, x2, x1y, x2y, x1Sq, x2Sq, x1x2
-    real(dp) :: TDayMax_temp, TDayMin_temp
+subroutine fTnxReference_erase()
+    call unlink(GetTnxReferenceFileFull())
+end subroutine fTnxReference_erase
 
-    ! 1. initialize
-    call SetSimulation_DelayedDays(0) ! required for CalculateETpot
-    GDDL12SS = GDDL12 ! to calculate SumKcTop (no stress)
-    BNor100 = real(undef_int, kind=dp)
-    ! Maximum sum Kc (no stress)
-    SumKcTop = SeasonalSumOfKcPot(TheDaysToCCini, TheGDDaysToCCini,&
-        L0, L12, L123, L1234, GDDL0, GDDL12, GDDL123, GDDL1234,&
-        CCo, CCx, CGC, GDDCGC, CDC, GDDCDC, KcTop, KcDeclAgeing, &
-        CCeffectProcent,Tbase, Tupper, TDayMin, TDayMax, GDbioLow, &
-        CO2Given, TheModeCycle)
-    ! Get PercentLagPhase (for estimate WPi during yield formation)
-    if ((TheCropType == subkind_Tuber) .or. (TheCropType == subkind_grain)) then
-        ! DaysToFlowering corresponds with Tuberformation
-        DaysYieldFormation = roundc(RefHI/RatedHIdt, mold=1)
-        if (CropDeterm) then
-            HIGC = HarvestIndexGrowthCoefficient(real(RefHI, kind=dp), RatedHIdt)
-            call GetDaySwitchToLinear(RefHI, RatedHIdt, &
-                    HIGC, tSwitch, HIGClinear)
-        else
-            tSwitch = roundc(DaysYieldFormation/3._dp, mold=1)
-        end if
-    end if
 
-    ! 2. Biomass production (or Salt stress) for various CCx reductions
-    do Si = 1, 10
-        ! various CCx reduction
-        ! CCx reduction
-        SiPr = int(10*(Si-1), kind=int8)
-        StressMatrix(Si)%CCxReduction = SiPr
-        ! adjustment CC
-        call CropStressParametersSoilSalinity(SiPr, TheCCsaltDistortion, &
-            CCo, CCx, CGC, GDDCGC, CropDeterm, L12, LFlor, LengthFlor, L123,&
-            GDDL12, GDDFlor, GDDLengthFlor, GDDL123, TheModeCycle,&
-            StressResponse)
-        ! adjusted length of Max canopy cover
-        RatDGDD = 1
-        if ((StressResponse%RedCCX == 0) .and.&
-            (StressResponse%RedCGC == 0)) then
-            L12SS = L12
-            GDDL12SS = GDDL12
-        else
-            CCToReach = 0.98_dp*(1._dp-StressResponse%RedCCX/100._dp)*CCx
-            L12SS = DaysToReachCCwithGivenCGC(CCToReach, CCo, &
-                 (1._dp-StressResponse%RedCCX/100._dp)*CCx,&
-                 CGC*(1._dp-StressResponse%RedCGC/100._dp), L0)
-            if (TheModeCycle == modeCycle_GDDays) then
-                TDayMax_temp = TDayMax
-                TDayMin_temp = TDayMin
-                GDDL12SS = GrowingDegreeDays(L12SS, CropDNr1, Tbase, &
-                           Tupper, TDayMin_temp, TDayMax_temp)
-            end if
-            if ((TheModeCycle == modeCycle_GDDays) .and.&
-                (GDDL12SS < GDDL123)) then
-                RatDGDD = (L123-L12SS)*1._dp/(GDDL123-GDDL12SS)
-            end if
-        end if
+! fTnxReference365Days
 
-        ! biomass production
-        BNor = Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
-                L0, L12, L12SS, L123, L1234, LFlor,&
-                GDDL0, GDDL12, GDDL12SS, GDDL123, GDDL1234,&
-                WPyield, DaysYieldFormation, tSwitch,&
-                CCo, CCx, CGC, GDDCGC, CDC, GDDCDC,&
-                KcTop, KcDeclAgeing, CCeffectProcent, WPveg, CO2Given,&
-                Tbase, Tupper, TDayMin, TDayMax, GDbioLow, RatDGDD, SumKcTop,&
-                SiPr, StressResponse%RedCGC, StressResponse%RedCCX,&
-                StressResponse%RedWP, StressResponse%RedKsSto, &
-                0_int8, 0, StressResponse%CDecline, -0.01_dp,&
-                TheModeCycle, .false., .false.)
-        if (Si == 1) then
-            BNor100 = BNor
-            BioMProc = 100._dp
-            StressMatrix(1)%SaltProc = 0._dp
-        else
-            if (BNor100 > 0.00001_dp) then
-                BioMProc = 100._dp * BNor/BNor100
-                StressMatrix(Si)%SaltProc = 100._dp - BioMProc
-            else
-                StressMatrix(Si)%SaltProc = 0._dp
-            end if
-        end if
-        StressMatrix(Si)%SaltSquare = &
-             StressMatrix(Si)%SaltProc *&
-             StressMatrix(Si)%SaltProc
-        ! end stress level
-    end do
+subroutine fTnxReference365Days_open(filename, mode)
+    !! Opens the given file, assigning it to the 'fTnxReference365Days' file handle.
+    character(len=*), intent(in) :: filename
+        !! name of the file to assign the file handle to
+    character, intent(in) :: mode
+        !! open the file for reading ('r'), writing ('w') or appending ('a')
 
-    ! 3. CCx - Salt stress relationship
-    Yavg = 0._dp
-    X1avg = 0._dp
-    X2avg = 0._dp
-    do Si = 1, 10
-        ! various CCx reduction
-        Yavg = Yavg + StressMatrix(Si)%CCxReduction
-        X1avg = X1avg + StressMatrix(Si)%SaltProc
-        X2avg = X2avg + StressMatrix(Si)%SaltSquare
-    end do
-    Yavg  = Yavg/10._dp
-    X1avg = X1avg/10._dp
-    X2avg = X2avg/10._dp
-    SUMx1y  = 0._dp
-    SUMx2y  = 0._dp
-    SUMx1Sq = 0._dp
-    SUMx2Sq = 0._dp
-    SUMx1x2 = 0._dp
-    do Si = 1, 10
-        ! various CCx reduction
-        y     = StressMatrix(Si)%CCxReduction - Yavg
-        x1    = StressMatrix(Si)%SaltProc - X1avg
-        x2    = StressMatrix(Si)%SaltSquare - X2avg
-        x1y   = x1 * y
-        x2y   = x2 * y
-        x1Sq  = x1 * x1
-        x2Sq  = x2 * x2
-        x1x2  = x1 * x2
-        SUMx1y  = SUMx1y + x1y
-        SUMx2y  = SUMx2y + x2y
-        SUMx1Sq = SUMx1Sq + x1Sq
-        SUMx2Sq = SUMx2Sq + x2Sq
-        SUMx1x2 = SUMx1x2 + x1x2
-    end do
+    call open_file(fTnxReference365Days, filename, mode, fTnxReference365Days_iostat)
+end subroutine fTnxReference365Days_open
 
-    if (abs(roundc(SUMx1x2*1000._dp, mold=1)) /= 0) then
-        Coeffb2Salt = (SUMx1y - (SUMx2y * SUMx1Sq)/SUMx1x2)/&
-                      (SUMx1x2 - (SUMx1Sq * SUMx2Sq)/SUMx1x2)
-        Coeffb1Salt = (SUMx1y - Coeffb2Salt * SUMx1x2)/SUMx1Sq
-        Coeffb0Salt = Yavg - Coeffb1Salt*X1avg - Coeffb2Salt*X2avg
 
-        Salt10 =  StressMatrix(2)%SaltProc
-        Salt20 =  StressMatrix(3)%SaltProc
-        Salt30 =  StressMatrix(4)%SaltProc
-        Salt40 =  StressMatrix(5)%SaltProc
-        Salt50 =  StressMatrix(5)%SaltProc
-        Salt60 =  StressMatrix(7)%SaltProc
-        Salt70 =  StressMatrix(8)%SaltProc
-        Salt80 =  StressMatrix(9)%SaltProc
-        Salt90 =  StressMatrix(10)%SaltProc
+subroutine fTnxReference365Days_write(line, advance_in)
+    !! Writes the given line to the fTnxReference365Days file.
+    character(len=*), intent(in) :: line
+        !! line to write
+    logical, intent(in), optional :: advance_in
+        !! whether or not to append a newline character
+
+    logical :: advance
+
+    if (present(advance_in)) then
+        advance = advance_in
     else
-        Coeffb2Salt = real(undef_int, kind=dp)
-        Coeffb1Salt = real(undef_int, kind=dp)
-        Coeffb0Salt = real(undef_int, kind=dp)
+        advance = .true.
     end if
-end subroutine CCxSaltStressRelationship
+    call write_file(fTnxReference365Days, line, advance, fTnxReference365Days_iostat)
+end subroutine fTnxReference365Days_write
+
+
+subroutine fTnxReference365Days_close()
+    close(fTnxReference365Days)
+end subroutine fTnxReference365Days_close
+
+
+subroutine fTnxReference365Days_erase()
+    call unlink(GetTnxReference365DaysFileFull())
+end subroutine fTnxReference365Days_erase
+
+
+subroutine GetMonthlyTemperatureDataSetFromTnxReferenceFile(Monthi, TminDataSet, TmaxDataSet)
+    integer(int32), intent(in) :: Monthi
+    type(rep_DayEventDbl), dimension(31) , intent(inout) :: TminDataSet
+    type(rep_DayEventDbl), dimension(31) , intent(inout) :: TmaxDataSet
+
+    integer(int32) :: Dayi, DayN
+    integer(int32) :: DNR
+    integer(int32) :: t1, t2, ni
+    real(dp) :: C1Min, C2Min, C3Min
+    real(dp) :: C1Max, C2Max, C3Max
+    real(dp) :: aOver3Min, bOver2Min, cMin
+    real(dp) :: aOver3Max, bOver2Max, cMax
+    character(len=:), allocatable :: FullFileName
+
+    ni=30
+
+    !call GetSetofThreeMonthsUndefYear(Monthi, &
+    !     C1Min, C2Min, C3Min, C1Max, C2Max, C3Max)
+    if (Monthi == 1) then
+        C1Min = GetTminTnxReference12MonthsRun_i(12)
+        C1Max = GetTmaxTnxReference12MonthsRun_i(12)
+    else
+        C1Min = GetTminTnxReference12MonthsRun_i(Monthi-1)
+        C1Max = GetTmaxTnxReference12MonthsRun_i(Monthi-1)
+    end if
+    C2Min = GetTminTnxReference12MonthsRun_i(Monthi)
+    C2Max = GetTmaxTnxReference12MonthsRun_i(Monthi)
+    if (Monthi == 12) then
+        C3Min = GetTminTnxReference12MonthsRun_i(1)
+        C3Max = GetTmaxTnxReference12MonthsRun_i(1)
+    else
+        C3Min = GetTminTnxReference12MonthsRun_i(Monthi+1)
+        C3Max = GetTmaxTnxReference12MonthsRun_i(Monthi+1)
+    end if
+
+    C1Min = C1Min*ni
+    C1Max = C1Max*ni
+    C2Min = C2Min*ni
+    C2Max = C2Max*ni
+    C3Min = C3Min*ni
+    C3Max = C3Max*ni
+
+    call DetermineDayNr(1, Monthi, 1901, DNR)
+    DayN = DaysInMonth(Monthi)
+
+    call GetInterpolationParameters(C1Min, C2Min, C3Min, &
+                   aOver3Min, bOver2Min, cMin)
+    call GetInterpolationParameters(C1Max, C2Max, C3Max, &
+                   aOver3Max, bOver2Max, cMax)
+        !WRITE(*, '(A, 6f10.2)') 'Int C1Min ...: ', C1Min, C2Min, C3Min, aOver3Min, bOver2Min, cMin
+
+    t1 = 30
+    do Dayi = 1, DayN
+        t2 = t1 + 1
+        TminDataSet(Dayi)%DayNr = DNR+Dayi-1
+        TmaxDataSet(Dayi)%DayNr = DNR+Dayi-1
+        TminDataSet(Dayi)%Param = aOver3Min*(t2*t2*t2-t1*t1*t1) &
+            + bOver2Min*(t2*t2-t1*t1) + cMin*(t2-t1)
+        TmaxDataSet(Dayi)%Param = aOver3Max*(t2*t2*t2-t1*t1*t1) &
+            + bOver2Max*(t2*t2-t1*t1) + cMax*(t2-t1)
+        t1 = t2
+        !WRITE(*, '(A, i4, f10.2)') 'TminDataSet(Dayi)%DayNr: ', TminDataSet(Dayi)%DayNr, TminDataSet(Dayi)%Param
+    end do
+    do Dayi = (DayN+1), 31 ! Give to remaining days (day 29,30 or 31) the DayNr of the last day of the month
+        TminDataSet(Dayi)%DayNr = DNR+DayN-1
+        TmaxDataSet(Dayi)%DayNr = DNR+DayN-1
+        TminDataSet(Dayi)%Param = 0._dp
+        TmaxDataSet(Dayi)%Param = 0._dp
+    end do
+
+    contains
+
+
+!    subroutine GetSetofThreeMonthsUndefYear(Monthi, &
+!            C1Min, C2Min, C3Min, C1Max, C2Max, C3Max)
+!        integer(int32), intent(in) :: Monthi
+!        real(dp), intent(inout) :: C1Min
+!        real(dp), intent(inout) :: C2Min
+!        real(dp), intent(inout) :: C3Min
+!        real(dp), intent(inout) :: C1Max
+!        real(dp), intent(inout) :: C2Max
+!        real(dp), intent(inout) :: C3Max
+!
+!        integer(int32) :: fhandle
+!        integer(int32) :: Mfile, Nri, Obsi, rc
+!        logical :: OK3
+!
+!        ! 1. Prepare record
+!        open(newunit=fhandle, file=trim(GetTnxReferenceFileFull()), &
+!                     status='old', action='read', iostat=rc)
+!        read(fhandle, *, iostat=rc) ! description
+!        read(fhandle, *, iostat=rc) ! time step
+!        read(fhandle, *, iostat=rc) ! day
+!        read(fhandle, *, iostat=rc) ! month
+!        read(fhandle, *, iostat=rc) ! year
+!        read(fhandle, *, iostat=rc)
+!        read(fhandle, *, iostat=rc)
+!        read(fhandle, *, iostat=rc)
+!
+!        Mfile = 1
+!        OK3 = .false.
+!
+!        ! 2. If first month
+!        if (Monthi == 1) then
+!            ! get Tnx Month 12
+!            do Monthi = 1, 11
+!                read(fhandle, *, iostat=rc)
+!            end do
+!            call ReadMonth(C1Min, C1Max, fhandle, rc)
+!            ! reset
+!            rewind(fhandle)
+!            do Monthi = 1, 8
+!                read(fhandle, *, iostat=rc)
+!            end do
+!            ! get Tnx Month 1 and 2
+!            call ReadMonth(C2Min, C2Max, fhandle, rc)  ! month 1
+!            call ReadMonth(C3Min, C3Max, fhandle, rc)  ! month 2
+!            OK3 = .true.
+!        end if
+!        
+!        ! 3. If last month
+!        if (Monthi == 12) then
+!            ! get Tnx Month 11 and 12
+!            do Monthi = 1, 10
+!                read(fhandle, *, iostat=rc)
+!            end do
+!            call ReadMonth(C1Min, C1Max, fhandle, rc)  ! month 11
+!            call ReadMonth(C2Min, C2Max, fhandle, rc)  ! month 12
+!            ! reset
+!            rewind(fhandle)
+!            ! get Tnx Month 1
+!            do Monthi = 1, 8
+!                read(fhandle, *, iostat=rc)
+!            end do
+!            call ReadMonth(C3Min, C3Max, fhandle, rc)  ! month 1
+!            OK3 = .true.
+!        end if
+!        
+!        ! 4. IF not first or last month
+!        if(.not. OK3) then
+!            ! determine Position Monthi
+!            Obsi = 1
+!            do while (.not. OK3)
+!                if (Monthi == Mfile) then
+!                   OK3 = .true.
+!                else
+!                   Mfile = Mfile + 1
+!                  Obsi = Obsi + 1
+!                end if
+!            end do
+!            ! get to Monthi-1
+!            do Nri = 1, (Obsi-2)
+!                read(fhandle, *, iostat=rc)
+!            end do
+!            ! Get Tnx (Monthi-1), Monthi, (Monthi+1)
+!            call ReadMonth(C1Min, C1Max, fhandle, rc) ! Monthi-1
+!            call ReadMonth(C2Min, C2Max, fhandle, rc) ! Monthi
+!            call ReadMonth(C3Min, C3Max, fhandle, rc) ! Monthi+1
+!        end if
+!        close(fhandle)
+!    end subroutine GetSetofThreeMonthsUndefYear
+!
+
+    subroutine ReadMonth(CiMin, CiMax, fhandle, rc)
+        real(dp), intent(inout) :: CiMin
+        real(dp), intent(inout) :: CiMax
+        integer(int32), intent(in) :: fhandle
+        integer(int32), intent(inout) :: rc
+
+        integer(int32), parameter :: ni = 30 ! simplification give better results for all cases
+        character(len=255) :: StringREAD
+
+        read(fhandle, '(a)', iostat=rc) StringREAD
+        call SplitStringInTwoParams(StringREAD, CiMin, CiMax)
+        CiMin = CiMin * ni
+        CiMax = CiMax * ni
+    end subroutine ReadMonth
+
+
+    subroutine GetInterpolationParameters(C1, C2, C3, &
+                          aOver3, bOver2, c)
+        real(dp), intent(in) :: C1
+        real(dp), intent(in) :: C2
+        real(dp), intent(in) :: C3
+        real(dp), intent(inout) :: aOver3
+        real(dp), intent(inout) :: bOver2
+        real(dp), intent(inout) :: c
+
+        ! n1=n2=n3=30 --> better parabola
+        aOver3 = (C1-2._dp*C2+C3)/(6._dp*30._dp*30._dp*30._dp)
+        bOver2 = (-6._dp*C1+9._dp*C2-3._dp*C3)/(6._dp*30._dp*30._dp)
+        c = (11._dp*C1-7._dp*C2+2._dp*C3)/(6._dp*30._dp)
+    end subroutine GetInterpolationParameters
+end subroutine GetMonthlyTemperatureDataSetFromTnxReferenceFile
+
+
 
 end module ac_tempprocessing

--- a/src/tempprocessing.f90
+++ b/src/tempprocessing.f90
@@ -2128,7 +2128,7 @@ subroutine LoadSimulationRunProject(NrRun)
         call CompleteClimateDescription(temperature_record)
         call SetTemperatureRecord(temperature_record)
     end if
-/
+
     ! Create Temperature Reference file 
     if (GetTemperatureFile() /= '(External)') then
         call CreateTnxReferenceFile(GetTemperatureFile(),GetTnxReferenceFile(),GetTnxReferenceYear());

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -64,7 +64,7 @@ function GetReleaseDate() result(str)
     !! Returns a string containing the month and year of the release.
     character(len=:), allocatable :: str
 
-    str = 'August 2023'
+    str = 'August 2024'
 end function GetReleaseDate
 
 
@@ -72,7 +72,7 @@ function GetVersionString() result(str)
     !! Returns a string containing the version number (major+minor).
     character(len=:), allocatable :: str
 
-    str = '7.1'
+    str = '7.2'
 end function GetVersionString
 
 
@@ -247,5 +247,62 @@ subroutine threestrings2threepointers(string1, string2, string3, &
     f_string3 = string3 // c_null_char
     c_pointer3 = c_loc(f_string3)
 end subroutine threestrings2threepointers
+
+
+subroutine write_file(fhandle, line, advance, iostat)
+    !! Writes one line to a file.
+    integer, intent(in) :: fhandle
+        !! file handle of an already-opened file
+    character(len=*), intent(in) :: line
+        !! line to write to the file
+    logical, intent(in) :: advance
+        !! whether or not to append a newline character
+    integer, intent(out) :: iostat
+        !! IO status returned by write()
+
+    character(len=:), allocatable :: advance_str
+
+    if (advance) then
+        advance_str = 'yes'
+    else
+        advance_str = 'no'
+    end if
+
+    write(fhandle, '(a)', advance=advance_str, iostat=iostat) line
+end subroutine write_file
+
+
+subroutine open_file(fhandle, filename, mode, iostat)
+    !! Opens a file in the given mode.
+    integer, intent(out) :: fhandle
+        !! file handle to be used for the open file
+    character(len=*), intent(in) :: filename
+        !! name of the file to assign the file handle to
+    character, intent(in) :: mode
+        !! open the file for reading ('r'), writing ('w') or appending ('a')
+    integer, intent(out) :: iostat
+        !! IO status returned by open()
+
+    logical :: file_exists
+
+    inquire(file=filename, exist=file_exists)
+
+    if (mode == 'r') then
+        open(newunit=fhandle, file=trim(filename), status='old', &
+             action='read', iostat=iostat)
+    elseif (mode == 'a') then
+        if (file_exists) then
+            open(newunit=fhandle, file=trim(filename), status='old', &
+                 position='append', action='write', iostat=iostat)
+        else
+            open(newunit=fhandle, file=trim(filename), status='new', &
+                 action='write', iostat=iostat)
+        end if
+    elseif (mode == 'w') then
+        open(newunit=fhandle, file=trim(filename), status='replace', &
+             action='write', iostat=iostat)
+    end if
+end subroutine open_file
+
 
 end module ac_utils


### PR DESCRIPTION
This PR includes all scientific code changes related to the V72 release. See related release notes published at the FAO AquaCrop website.
The PR also includes 
-cleanup of unused variables in fortran code
-two corrections of testing floating point numbers on equality (now making appropriate use of epsilon)
-a bug fix (difference with old Pascal code) in the subroutine CalculateEffectiveRainfall which did not affect results of the testcases. 

Test results (DEBUG=0 and DEBUG=1):
CassavaTest.PRO
Alf2Isp50.PRM
Ottawa.PRM
CassavaTestMonth.PRO (with monthly meteo data as input)
--> zero-diff with pascal executable apart from rounding differences (last digit) due to rounding digits / insignificant digits (extra digits that extend beyond the number of digits allowed by the given precision), like e.g. 0.05000000030935 or 0.04999999956757 are rounded to either 0.1 or 0.0 in fortran and pascal output.