### PR TITLE
WIP: corrections to v7.2 and LIS coupling

### DIFF
--- a/src/global.f90
+++ b/src/global.f90
@@ -2645,7 +2645,7 @@ real(dp) function KsAny(Wrel, pULActual, pLLActual, ShapeFactor)
 
     pRelativeLLUL = (Wrel - pULActual_local)/(pLLActual - pULActual_local)
 
-    if (pRelativeLLUL <= 0._dp) then
+    if (pRelativeLLUL <= epsilon(0._dp)) then
         KsVal = 1._dp
     elseif (pRelativeLLUL >= 1._dp) then
         KsVal = 0._dp
@@ -8375,6 +8375,11 @@ integer(int32) function SumCalendarDaysReferenceTnx(ValGDDays, RefCropDay1,&
 
             ! TminCropReference and TmaxCropReference arrays contain the TemperatureFilefull data
             i = StartDayNr - RefCropDay1
+
+            ! For crops with very long cycles (unrealistic but avoid crashing)
+            if (i >= 365) then
+                i = i - 365
+            end if
 
             do while (RemainingGDDays > 0.1_dp)
                 i = i + 1

--- a/src/global.f90
+++ b/src/global.f90
@@ -5372,6 +5372,7 @@ real(dp) function SeasonalSumOfKcPot(TheDaysToCCini, TheGDDaysToCCini, L0, L12, 
     integer(int32) :: Dayi
     integer(int32) :: rc
     logical :: GrowthON
+    integer :: i
 
     ! 1. Open Temperature file
     if ((GetTemperatureFile() /= '(None)') .and. &
@@ -5438,14 +5439,19 @@ real(dp) function SeasonalSumOfKcPot(TheDaysToCCini, TheGDDaysToCCini, L0, L12, 
     end if
 
     ! 3. Calculate Sum
+    i = 0
     do Dayi = 1, L1234
         ! 3.1 calculate growing degrees for the day
         if (GetTemperatureFile() == '(None)') then
             GDDi = DegreesDay(Tbase, Tupper, TDayMin, TDayMax, &
                                     GetSimulParam_GDDMethod())
         elseif (GetTemperatureFile() == '(External)') then
-            Tndayi = real(GetTminRun_i(GetCrop_Day1()-GetSimulation_FromDayNr()+Dayi),kind=dp)
-            Txdayi = real(GetTmaxRun_i(GetCrop_Day1()-GetSimulation_FromDayNr()+Dayi),kind=dp)
+            i = i + 1
+            if (i == size(GetTminCropReferenceRun())) then
+                i = 1
+            endif
+            Tndayi = real(GetTminCropReferenceRun_i(i),kind=dp)
+            Txdayi = real(GetTmaxCropReferenceRun_i(i),kind=dp)
             GDDi = DegreesDay(Tbase, Tupper, Tndayi, Txdayi, &
                                     GetSimulParam_GDDMethod())
         else
@@ -8332,6 +8338,68 @@ subroutine CompleteClimateDescription(ClimateRecord)
                              ' ' // yearStr
 end subroutine CompleteClimateDescription
 
+integer(int32) function SumCalendarDaysReferenceTnx(ValGDDays, RefCropDay1,&
+                                        StartDayNr, Tbase, Tupper,&
+                                        TDayMin, TDayMax)
+    integer(int32), intent(in) :: ValGDDays
+    integer(int32), intent(in) :: RefCropDay1
+    integer(int32), intent(in) :: StartDayNr
+    real(dp), intent(in) :: Tbase
+    real(dp), intent(in) :: Tupper
+    real(dp), intent(in) :: TDayMin
+    real(dp), intent(in) :: TDayMax
+
+    integer(int32) :: i
+    integer(int32) :: NrCDays
+    real(dp) :: RemainingGDDays, DayGDD
+    real(dp) :: TDayMin_loc, TDayMax_loc
+
+    TDayMin_loc = TDayMin
+    TDayMax_loc = TDayMax
+
+    NrCdays = 0
+    if (ValGDDays > 0) then
+        if (GetTnxReferenceFile() == '(None)') then
+            ! given average Tmin and Tmax
+            DayGDD = DegreesDay(Tbase, Tupper, &
+                       TDayMin_loc, TDayMax_loc, GetSimulParam_GDDMethod())
+            if (abs(DayGDD) < epsilon(1._dp)) then
+                NrCDays = 0
+            else
+                NrCDays = roundc(ValGDDays/DayGDD, mold=1_int32)
+            end if
+        else
+            ! Get TCropReference: mean daily Tnx (365 days) from RefCropDay1 onwards
+            ! determine corresponding calendar days
+            RemainingGDDays = ValGDDays
+
+            ! TminCropReference and TmaxCropReference arrays contain the TemperatureFilefull data
+            i = StartDayNr - RefCropDay1
+
+            do while (RemainingGDDays > 0.1_dp)
+                i = i + 1
+                if (i == size(GetTminCropReferenceRun())) then
+                    i = 1
+                end if
+                TDayMin_loc = GetTminCropReferenceRun_i(i)
+                TDayMax_loc = GetTmaxCropReferenceRun_i(i)
+
+                DayGDD = DegreesDay(Tbase, Tupper, TDayMin_loc, &
+                                    TDayMax_loc, &
+                                    GetSimulParam_GDDMethod())
+                if (DayGDD > RemainingGDDays) then
+                    if (roundc((DayGDD-RemainingGDDays)/RemainingGDDays,mold=1) >= 1) then
+                        NrCDays = NrCDays + 1
+                    end if
+                else
+                    NrCDays = NrCDays + 1
+                end if
+                RemainingGDDays = RemainingGDDays - DayGDD
+            end do
+        end if
+    end if
+    SumCalendarDaysReferenceTnx = NrCDays
+end function SumCalendarDaysReferenceTnx
 
 
 !! Global variables section !!

--- a/src/preparefertilitysalinity.f90
+++ b/src/preparefertilitysalinity.f90
@@ -59,7 +59,8 @@ use ac_global, only: CO2ref,&
                      subkind_Grain,  & 
                      subkind_Grain, & 
                      subkind_Tuber, & 
-                     subkind_Vegetative, & 
+                     subkind_Vegetative, &
+                     SumCalendarDaysReferenceTnx, &
                      TimeToMaxCanopySF, & 
                      undef_double, & 
                      undef_int
@@ -88,69 +89,6 @@ implicit none
 
 contains
 
-
-integer(int32) function SumCalendarDaysReferenceTnx(ValGDDays, RefCropDay1,&
-                                        StartDayNr, Tbase, Tupper,&
-                                        TDayMin, TDayMax)
-    integer(int32), intent(in) :: ValGDDays
-    integer(int32), intent(in) :: RefCropDay1
-    integer(int32), intent(in) :: StartDayNr
-    real(dp), intent(in) :: Tbase
-    real(dp), intent(in) :: Tupper
-    real(dp), intent(in) :: TDayMin
-    real(dp), intent(in) :: TDayMax
-
-    integer(int32) :: i
-    integer(int32) :: NrCDays
-    real(dp) :: RemainingGDDays, DayGDD
-    real(dp) :: TDayMin_loc, TDayMax_loc
-    
-    TDayMin_loc = TDayMin
-    TDayMax_loc = TDayMax
-
-    NrCdays = 0
-    if (ValGDDays > 0) then
-        if (GetTnxReferenceFile() == '(None)') then
-            ! given average Tmin and Tmax
-            DayGDD = DegreesDay(Tbase, Tupper, &
-                       TDayMin_loc, TDayMax_loc, GetSimulParam_GDDMethod())
-            if (abs(DayGDD) < epsilon(1._dp)) then
-                NrCDays = 0
-            else
-                NrCDays = roundc(ValGDDays/DayGDD, mold=1_int32)
-            end if
-        else
-            ! Get TCropReference: mean daily Tnx (365 days) from RefCropDay1 onwards
-            ! determine corresponding calendar days
-            RemainingGDDays = ValGDDays
-
-            ! TminCropReference and TmaxCropReference arrays contain the TemperatureFilefull data
-            i = StartDayNr - RefCropDay1
-
-            do while (RemainingGDDays > 0.1_dp)
-                i = i + 1
-                if (i == size(GetTminCropReferenceRun())) then
-                    i = 1
-                end if
-                TDayMin_loc = GetTminCropReferenceRun_i(i)
-                TDayMax_loc = GetTmaxCropReferenceRun_i(i)
-
-                DayGDD = DegreesDay(Tbase, Tupper, TDayMin_loc, &
-                                    TDayMax_loc, &
-                                    GetSimulParam_GDDMethod())
-                if (DayGDD > RemainingGDDays) then
-                    if (roundc((DayGDD-RemainingGDDays)/RemainingGDDays,mold=1) >= 1) then
-                        NrCDays = NrCDays + 1
-                    end if
-                else
-                    NrCDays = NrCDays + 1
-                end if
-                RemainingGDDays = RemainingGDDays - DayGDD
-            end do
-        end if
-    end if
-    SumCalendarDaysReferenceTnx = NrCDays
-end function SumCalendarDaysReferenceTnx
 
 
 subroutine AdjustCalendarDaysReferenceTnx(PlantDayNr, TheCropType, &
@@ -236,7 +174,7 @@ subroutine AdjustCalendarDaysReferenceTnx(PlantDayNr, TheCropType, &
 
     CGC = (real(GDDL12, kind=dp)/real(L12, kind=dp)) * GDDCGC
     call GDDCDCToCDC(PlantDayNr, L123, GDDL123, GDDL1234, CCx, GDDCDC, &
-        Tbase, Tupper, TDayMin, TDayMax, CDC)
+        Tbase, Tupper, TDayMin, TDayMax, CDC, .true.)
     if ((TheCropType == subkind_Grain) .or. (TheCropType == subkind_Tuber)) then
         RatedHIdt = real(RefHI, kind=dp)/real(LHImax, kind=dp)
     end if

--- a/src/preparefertilitysalinity.f90
+++ b/src/preparefertilitysalinity.f90
@@ -205,7 +205,8 @@ subroutine DailyTnxReferenceFileCoveringCropPeriod(CropFirstDay)
     real(sp) :: Tlow, Thigh
     character(len=1025) :: TempString
 
-    if (FileExists(GetTnxReferenceFileFull())) then
+    if (FileExists(GetTnxReferenceFileFull()) &
+        .or.(GetTnxReferenceFile() == '(External)')) then
         ! CropFirstDay = DayNr1 in undefined year
         call DetermineDate(CropFirstDay, Dayi, Monthi, Yeari)
         call DetermineDayNr(Dayi, Monthi, (1901), DayNr1)

--- a/src/rootunit.f90
+++ b/src/rootunit.f90
@@ -141,7 +141,7 @@ real(dp) function AdjustedRootingDepth(&
         end if
 
         ! -- 3.3 correction for early senescence
-        if ((CCact <= 0.0_dp) .and. (CCpot > 50.0_dp)) then
+        if ((CCact <= epsilon(0.0_dp)) .and. (CCpot > 50.0_dp)) then
             dZ = 0.0_dp
         end if
 

--- a/src/run.f90
+++ b/src/run.f90
@@ -7428,7 +7428,9 @@ subroutine WriteDailyResults(DAP, WPi)
 
     ! 0. info day
     write(tempstring, '(5i6)') Di, Mi, Yi, DAP_loc, GetStageCode()
-    call fDaily_write(trim(tempstring), .false.)
+    if (GetTemperatureFile() /= '(External)') then
+        call fDaily_write(trim(tempstring), .false.)
+    endif
 
 
     ! 1. Water balance
@@ -7609,7 +7611,9 @@ subroutine WriteDailyResults(DAP, WPi)
     ! 3. Profile/Root zone - Soil water content
     if (GetOut3Prof()) then
         write(tempstring, '(f10.1)') GetTotalWaterContent_EndDay()
-        call fDaily_write(trim(tempstring), .false.)
+        if (GetTemperatureFile() /= '(External)') then
+            call fDaily_write(trim(tempstring), .false.)
+        endif
         if (GetRootingDepth() < epsilon(0._dp)) then
             call SetRootZoneWC_Actual(undef_double)
         else
@@ -7626,7 +7630,9 @@ subroutine WriteDailyResults(DAP, WPi)
             end if
         end if
         write(tempstring, '(f9.1, f8.2)') GetRootZoneWC_actual(), GetRootingDepth()
-        call fDaily_write(trim(tempstring), .false.)
+        if (GetTemperatureFile() /= '(External)') then
+            call fDaily_write(trim(tempstring), .false.)
+        endif
         if (GetRootingDepth() < epsilon(0._dp)) then
             call SetRootZoneWC_Actual(undef_double)
             call SetRootZoneWC_FC(undef_double)
@@ -7644,14 +7650,18 @@ subroutine WriteDailyResults(DAP, WPi)
         write(tempstring, '(f8.1, 5f10.1)') GetRootZoneWC_actual(), &
                 GetRootZoneWC_SAT(), GetRootZoneWC_FC(), GetRootZoneWC_Leaf(), &
                 GetRootZoneWC_Thresh(), GetRootZoneWC_Sen()
-        call fDaily_write(trim(tempstring), .false.)
+        if (GetTemperatureFile() /= '(External)') then
+            call fDaily_write(trim(tempstring), .false.)
+        endif
         if ((GetOut4Salt()) .or. (GetOut5CompWC()) .or. (GetOut6CompEC()) &
             .or. (GetOut7Clim())) then
             write(tempstring, '(f10.1)') GetRootZoneWC_WP()
             call fDaily_write(trim(tempstring), .false.)
         else
             write(tempstring, '(f10.1)') GetRootZoneWC_WP()
-            call fDaily_write(tempstring)
+            if (GetTemperatureFile() /= '(External)') then
+                call fDaily_write(tempstring)
+            end if
         end if
     end if
 

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -981,14 +981,14 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
             if (BioAdj <= epsilon(1._dp)) then
                 StressSFadjNEW = 80
             else
-                StressSFadjNEW = roundc(Coeffb0 + Coeffb1*BioAdj + Coeffb2*BioAdj*BioAdj, &
-                                        mold=1_int8)
-                if (StressSFadjNEW < 0) then
+                if ((Coeffb0 + Coeffb1*BioAdj + Coeffb2*BioAdj*BioAdj) < 0) then
                     StressSFadjNEW = GetManagement_FertilityStress()
-                end if
-                if (StressSFadjNEW > 80) then
+                elseif ((Coeffb0 + Coeffb1*BioAdj + Coeffb2*BioAdj*BioAdj) > 80) then
                     StressSFadjNEW = 80
-                end if
+                else
+                    StressSFadjNEW = roundc(Coeffb0 + Coeffb1*BioAdj + Coeffb2*BioAdj*BioAdj, &
+                                            mold=1_int8)
+                endif
             end if
             if (StressSFadjNEW > GetManagement_FertilityStress()) then
                 StressSFadjNEW = GetManagement_FertilityStress()
@@ -3271,7 +3271,7 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
     real(dp) :: Crop_CCxAdjusted_temp
 
 
-    if ((SumGDDadjCC <= GetCrop_GDDaysToGermination()) &
+    if ((abs(SumGDDadjCC - GetCrop_GDDaysToGermination()) < epsilon(0._dp)) &
           .or. (roundc(SumGDDadjCC, mold=1) > GetCrop_GDDaysToHarvest())) then
         call SetCCiActual(0._dp)
     else
@@ -4647,6 +4647,9 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
     real(dp) :: Crop_CCxAdjusted_temp
 
     ! DetermineCCi
+    if ((VirtualTimeCC.eq.180)) then
+        KsSen = KsSen
+    endif
     if ((VirtualTimeCC < GetCrop_DaysToGermination()) &
         .or. (VirtualTimeCC > (GetCrop_DayN()-GetCrop_Day1()))) then
         call SetCCiActual(0._dp)

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -4647,9 +4647,6 @@ subroutine DetermineCCi(CCxTotal, CCoTotal, StressLeaf, FracAssim, &
     real(dp) :: Crop_CCxAdjusted_temp
 
     ! DetermineCCi
-    if ((VirtualTimeCC.eq.180)) then
-        KsSen = KsSen
-    endif
     if ((VirtualTimeCC < GetCrop_DaysToGermination()) &
         .or. (VirtualTimeCC > (GetCrop_DayN()-GetCrop_Day1()))) then
         call SetCCiActual(0._dp)

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -3271,7 +3271,7 @@ subroutine DetermineCCiGDD(CCxTotal, CCoTotal, &
     real(dp) :: Crop_CCxAdjusted_temp
 
 
-    if ((abs(SumGDDadjCC - GetCrop_GDDaysToGermination()) < epsilon(0._dp)) &
+    if ((SumGDDadjCC - GetCrop_GDDaysToGermination() < epsilon(0._dp)) &
           .or. (roundc(SumGDDadjCC, mold=1) > GetCrop_GDDaysToHarvest())) then
         call SetCCiActual(0._dp)
     else

--- a/src/tempprocessing.f90
+++ b/src/tempprocessing.f90
@@ -309,7 +309,8 @@ use ac_global , only: undef_int, &
                       TminTnxReference365DaysRun, &
                       TmaxTnxReference365DaysRun, &
                       TminCropReferenceRun, &
-                      TmaxCropReferenceRun
+                      TmaxCropReferenceRun, &
+                      SumCalendarDaysReferenceTnx
 use ac_kinds,  only: sp,&
                      dp, &
                      int8, &
@@ -960,6 +961,9 @@ integer(int32) function GrowingDegreeDays(ValPeriod, FirstDayPeriod, Tbase, &
             do while ((RemainingDays > 0) &
                         .and. (i<(GetSimulation_ToDayNr()-GetSimulation_FromDayNr()+1)))
                         i = i + 1
+                        if (i == size(GetTminRun())) then
+                            i = 1
+                        endif
                         TDayMin_local = real(GetTminRun_i(i),kind=dp)
                         TDayMax_local = real(GetTmaxRun_i(i),kind=dp)
                         DayGDD = DegreesDay(Tbase, Tupper, TDayMin_local, &
@@ -1157,6 +1161,9 @@ integer(int32) function SumCalendarDays(ValGDDays, FirstDayCrop, Tbase, Tupper,&
             do while ((RemainingGDDays > 0) &
                            .and. (i < (GetSimulation_ToDayNr()-GetSimulation_FromDayNr()+1)))
                   i = i + 1
+                  if (i == size(GetTminRun())) then
+                      i = 1
+                  endif
                   TDayMin_loc = real(GetTminRun_i(i),kind=dp)
                   TDayMax_loc = real(GetTmaxRun_i(i),kind=dp)
 
@@ -1559,7 +1566,8 @@ subroutine AdjustCalendarDays(PlantDayNr, InfoCropType,&
     if (Succes) then
         CGC = (real(GDDL12, kind=dp)/real(D12, kind=dp)) * GDDCGC
         call GDDCDCToCDC(PlantDayNr, D123, GDDL123, GDDHarvest,&
-               CCx, GDDCDC, Tbase, Tupper, tmp_NoTempFileTMin, tmp_NoTempFileTMax, CDC)
+               CCx, GDDCDC, Tbase, Tupper, tmp_NoTempFileTMin, tmp_NoTempFileTMax, CDC, &
+               .false.)
         call DetermineLengthGrowthStages(CCo, CCx, CDC, D0, DHarvest,&
                IsCGCGiven, TheDaysToCCini, &
                ThePlanting, D123, StLength, D12, CGC)
@@ -1667,7 +1675,7 @@ end subroutine AdjustCalendarCrop
 
 subroutine GDDCDCToCDC(PlantDayNr, D123, GDDL123, &
                        GDDHarvest, CCx, GDDCDC, Tbase, Tupper, &
-                       NoTempFileTMin, NoTempFileTMax, CDC)
+                       NoTempFileTMin, NoTempFileTMax, CDC, Reference)
     integer(int32), intent(in) :: PlantDayNr
     integer(int32), intent(in) :: D123
     integer(int32), intent(in) :: GDDL123
@@ -1679,6 +1687,7 @@ subroutine GDDCDCToCDC(PlantDayNr, D123, GDDL123, &
     real(dp), intent(in) :: NoTempFileTMin
     real(dp), intent(in) :: NoTempFileTMax
     real(dp), intent(inout) :: CDC
+    logical, intent(in) :: Reference
 
     integer(int32) :: ti, GDDi
     real(dp) :: CCi
@@ -1697,8 +1706,13 @@ subroutine GDDCDCToCDC(PlantDayNr, D123, GDDL123, &
                  * (exp(real(GDDi,kind=dp)*(GDDCDC*3.33_dp)/(CCx+2.29_dp))-1._dp) )
        ! CC at time ti
     end if
-    ti = SumCalendarDays(GDDi, (PlantDayNr+D123),&
-              Tbase, Tupper, NoTempFileTMin, NoTempFileTMax)
+    if (Reference) then
+        ti = SumCalendarDaysReferenceTnx(GDDi, (PlantDayNr+D123),&
+                (PlantDayNr+D123), Tbase, Tupper, NoTempFileTMin, NoTempFileTMax)
+    else
+        ti = SumCalendarDays(GDDi, (PlantDayNr+D123),&
+                Tbase, Tupper, NoTempFileTMin, NoTempFileTMax)
+    endif
     if (ti > 0) then
         CDC = (((CCx+2.29_dp)/real(ti, kind=dp)) &
                 * log(1._dp + ((1._dp-CCi/CCx)/0.05_dp)))/3.33_dp
@@ -2787,7 +2801,7 @@ real(dp) function Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
      real(dp) :: SumGDD, Tndayi, Txdayi, GDDi, CCi,&
                  CCxWitheredForB, TpotForB, EpotTotForB, SumKCi,&
                  fSwitch, WPi, SumBnor, SumKcTopSF, fCCx
-     integer(int32) :: Dayi, DayCC, Tadj, GDDTadj
+     integer(int32) :: Dayi, DayCC, Tadj, GDDTadj, i
      real(dp) :: CCoadj, CCxadj, CDCadj, GDDCDCadj, CCw, CCtotStar, CCwStar
      real(dp) :: SumGDDfromDay1, SumGDDforPlot, CCinitial,&
                  DayFraction, GDDayFraction, fWeed, WeedCorrection
@@ -2884,14 +2898,19 @@ real(dp) function Bnormalized(TheDaysToCCini, TheGDDaysToCCini,&
      end if
 
      ! 5. Calculate Bnormalized
+     i = 0
      do Dayi = 1, L1234
          ! 5.1 growing degrees for dayi
          if (GetTemperatureFile() == '(None)') then
              GDDi = DegreesDay(Tbase, Tupper, TDayMin, TDayMax,&
                                GetSimulParam_GDDMethod())
          elseif (GetTemperatureFile() == '(External)') then 
-             Tndayi = real(GetTminRun_i(GetCrop_Day1()-GetSimulation_FromDayNr()+Dayi),kind=dp)
-             Txdayi = real(GetTmaxRun_i(GetCrop_Day1()-GetSimulation_FromDayNr()+Dayi),kind=dp)
+             i = i + 1
+             if (i == size(GetTminCropReferenceRun())) then
+                 i = 1
+             end if
+             Tndayi = real(GetTminCropReferenceRun_i(i),kind=dp)
+             Txdayi = real(GetTmaxCropReferenceRun_i(i),kind=dp)
              GDDi = DegreesDay(Tbase, Tupper, Tndayi, Txdayi, &
                                     GetSimulParam_GDDMethod())
          else

--- a/src/tempprocessing.f90
+++ b/src/tempprocessing.f90
@@ -959,9 +959,10 @@ integer(int32) function GrowingDegreeDays(ValPeriod, FirstDayPeriod, Tbase, &
             RemainingDays = RemainingDays - 1
 
             do while ((RemainingDays > 0) &
-                        .and. (i<(GetSimulation_ToDayNr()-GetSimulation_FromDayNr()+1)))
+                        .and. (i<=(GetSimulation_ToDayNr()-GetSimulation_FromDayNr()+1)))
                         i = i + 1
-                        if (i == size(GetTminRun())) then
+                        ! LIS in for now run with a sim period of 365 days
+                        if (i == 366) then
                             i = 1
                         endif
                         TDayMin_local = real(GetTminRun_i(i),kind=dp)
@@ -1159,9 +1160,9 @@ integer(int32) function SumCalendarDays(ValGDDays, FirstDayCrop, Tbase, Tupper,&
             RemainingGDDays = RemainingGDDays - DayGDD
 
             do while ((RemainingGDDays > 0) &
-                           .and. (i < (GetSimulation_ToDayNr()-GetSimulation_FromDayNr()+1)))
+                           .and. (i <= (GetSimulation_ToDayNr()-GetSimulation_FromDayNr()+1)))
                   i = i + 1
-                  if (i == size(GetTminRun())) then
+                  if (i == 366) then
                       i = 1
                   endif
                   TDayMin_loc = real(GetTminRun_i(i),kind=dp)

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -95,25 +95,39 @@ function roundc_int32(x, mold) result(y)
     integer(int32), intent(in) :: mold
         !! Integer determining the kind of the integer result
     integer(int32) :: y
+    real(dp) :: x_clipped
 
-   if (abs(x - floor(x, kind=int32) - 0.5_dp) < epsilon(0._dp)) then
-       if (x > 0) then
-          if (mod(abs(trunc(x)),2) == 0) then
-              y = floor(x, kind=int32)
+    ! Check if x is within the tolerated range for int32 before rounding
+    if (x > 2147483647._dp) then
+        x_clipped = 2147483647._dp
+    elseif (x < -2147483648._dp) then
+        x_clipped = -2147483648._dp
+    else
+        x_clipped = x
+    end if
+
+    ! Rounding logic based on x_clipped
+    if (abs(x_clipped - floor(x_clipped, kind=int32) - 0.5_dp) < epsilon(0._dp)) then
+       if (x_clipped > 0) then
+          if (mod(abs(trunc(x_clipped)),2) == 0) then
+              y = floor(x_clipped, kind=int32)
           else
-              y = ceiling(x, kind=int32)
+              y = ceiling(x_clipped, kind=int32)
           end if
        else
-          if (mod(abs(trunc(x)),2) == 0) then
-              y = ceiling(x, kind=int32)
+          if (mod(abs(trunc(x_clipped)),2) == 0) then
+              y = ceiling(x_clipped, kind=int32)
           else
-              y = floor(x, kind=int32)
+              y = floor(x_clipped, kind=int32)
           end if
        end if
-    else !standard round for values not ending on 0.5
-       y = nint(x, kind=int32)
+    else
+       ! Standard round for values not ending on 0.5
+       y = nint(x_clipped, kind=int32)
     end if
+
 end function roundc_int32
+
 
 
 function roundc_int8(x, mold) result(y)
@@ -123,24 +137,37 @@ function roundc_int8(x, mold) result(y)
     integer(int8), intent(in) :: mold
         !! Integer determining the kind of the integer result
     integer(int8) :: y
+    real(dp) :: x_clipped
 
-    if (abs(x - floor(x, kind=int32) - 0.5_dp) < epsilon(0._dp)) then
-       if (x > 0) then
-          if (mod(abs(trunc(x)),2) == 0) then
-             y = floor(x, kind=int8)
+    ! Check if x is within the tolerated range for int8 before rounding
+    if (x > 127._dp) then
+        x_clipped = 127._dp
+    elseif (x < -128._dp) then
+        x_clipped = -128._dp
+    else
+        x_clipped = x
+    end if
+
+    ! Rounding logic based on x_clipped
+    if (abs(x_clipped - floor(x_clipped, kind=int32) - 0.5_dp) < epsilon(0._dp)) then
+       if (x_clipped > 0) then
+          if (mod(abs(trunc(x_clipped)),2) == 0) then
+             y = floor(x_clipped, kind=int8)
           else
-              y = ceiling(x, kind=int8)
+             y = ceiling(x_clipped, kind=int8)
           end if
        else
-          if (mod(abs(trunc(x)),2) == 0) then
-              y = ceiling(x, kind=int8)
+          if (mod(abs(trunc(x_clipped)),2) == 0) then
+             y = ceiling(x_clipped, kind=int8)
           else
-              y = floor(x, kind=int8)
+             y = floor(x_clipped, kind=int8)
           end if
        end if
-    else !standard round for values not ending on 0.5
-       y = nint(x, kind=int8)
+    else
+       ! Standard round for values not ending on 0.5
+       y = nint(x_clipped, kind=int8)
     end if
+
 end function roundc_int8
 
 


### PR DESCRIPTION
This PR gathers the changes to the src while debugging LIS-AC. 

## A. Changes only affecting LIS ('External' calls)
**A.1.** Correction in 'External' block in `tempprocessing.f90` calling TminRun and TmaxRun instead of TminCropReference and TmaxCropReference. 
**A.2.** Minor changes for LIS-AC (External if statements). Rewinding of the TminRun/TmaxRun everywhere to avoid LIS crashing. In LIS, the pixels that do not complete their growth cycle within the similation period are flagged in the output.
**A.3.** Block output writing in the console when running LIS (in `run.f90`)

## B. Changes affecting the StandAlone
**B.1.** It seems that the actual temperatures were used instead of the reference climatology. I changed this call and had to move the `SumCalendarDaysReferenceTnx` from `preparefertilityandsalinity.f90` to `global.f90` to avoid circularity issues. This change **did not affect the test case** (results for Ottawa are still identical) which I think makes sense. **Check with Dirk**
**B.2.** Changed remaining comparison with 0 statements with equality (`<= 0`, `>= 0`) to epsilon calls (`<= epsilon(0._dp)`, `>= epsilon(0._dp)`
**B.3.** In `DetermineBiomassAndYield` (`simul.f90`), I changed the order to avoid overflow of integers. This does not change anything to the scientific meaning of the code. However, this change is not necessary anymore because of B.4.
**B.4.** Implementation of overflow checks when using the roundc function in `utils.f90`

**CORRECTION:**
The output of the Ottawa testcase is still identical. 