### PR TITLE
ENH: ac72 patch bug fixes | fertility salinity stress and germination delay

### DIFF
--- a/src/run.f90
+++ b/src/run.f90
@@ -4336,19 +4336,6 @@ subroutine FinalizeRun2(NrRun, TheProjectType)
     end subroutine CloseEvalDataPerformEvaluation
 
 
-    subroutine CloseClimateFiles()
-        if (GetEToFile() /= '(None)') then
-            call fEToSIM_close()
-        end if
-        if (GetRainFile() /= '(None)') then
-            call fRainSIM_close()
-        end if
-        if (GetTemperatureFile() /= '(None)') then
-            call fTempSIM_close()
-        end if
-    end subroutine CloseClimateFiles
-
-
     subroutine CloseIrrigationFile()
         if ((GetIrriMode() == IrriMode_Manual) .or. (GetIrriMode() == IrriMode_Generate)) then
             call fIrri_close()
@@ -4362,6 +4349,19 @@ subroutine FinalizeRun2(NrRun, TheProjectType)
         end if
     end subroutine CloseManagementFile
 end subroutine FinalizeRun2
+
+
+subroutine CloseClimateFiles()
+    if (GetEToFile() /= '(None)') then
+        call fEToSIM_close()
+    end if
+    if (GetRainFile() /= '(None)') then
+        call fRainSIM_close()
+    end if
+    if (GetTemperatureFile() /= '(None)') then
+        call fTempSIM_close()
+    end if
+end subroutine CloseClimateFiles
 
 
 subroutine OpenIrrigationFile()
@@ -4848,18 +4848,24 @@ subroutine InitializeSimulationRunPart1()
     end if
 
     ! Maximum sum Kc (for reduction WP in season if soil fertility stress)
-    call SetSumKcTop(SeasonalSumOfKcPot(GetCrop_DaysToCCini(), &
-            GetCrop_GDDaysToCCini(), GetCrop_DaysToGermination(), &
-            GetCrop_DaysToFullCanopy(), GetCrop_DaysToSenescence(), &
-            GetCrop_DaysToHarvest(), GetCrop_GDDaysToGermination(), &
-            GetCrop_GDDaysToFullCanopy(), GetCrop_GDDaysToSenescence(), &
-            GetCrop_GDDaysToHarvest(), GetCrop_CCo(), GetCrop_CCx(), &
-            GetCrop_CGC(), GetCrop_GDDCGC(), GetCrop_CDC(), GetCrop_GDDCDC(), &
-            GetCrop_KcTop(), GetCrop_KcDecline(), real(GetCrop_CCEffectEvapLate(),kind=dp), &
-            GetCrop_Tbase(), GetCrop_Tupper(), GetSimulParam_Tmin(), &
-            GetSimulParam_Tmax(), GetCrop_GDtranspLow(), GetCO2i(), &
-            GetCrop_ModeCycle(), .true.))
-    call SetSumKcTopStress( GetSumKcTop() * GetFracBiomassPotSF())
+    if ((GetCrop_StressResponse_Calibrated() .eqv. .true.) .and. & 
+        (GetManagement_FertilityStress() > 0_int32)) then
+        call SetSumKcTop(SeasonalSumOfKcPot(GetCrop_DaysToCCini(), &
+                GetCrop_GDDaysToCCini(), GetCrop_DaysToGermination(), &
+                GetCrop_DaysToFullCanopy(), GetCrop_DaysToSenescence(), &
+                GetCrop_DaysToHarvest(), GetCrop_GDDaysToGermination(), &
+                GetCrop_GDDaysToFullCanopy(), GetCrop_GDDaysToSenescence(), &
+                GetCrop_GDDaysToHarvest(), GetCrop_CCo(), GetCrop_CCx(), &
+                GetCrop_CGC(), GetCrop_GDDCGC(), GetCrop_CDC(), GetCrop_GDDCDC(), &
+                GetCrop_KcTop(), GetCrop_KcDecline(), real(GetCrop_CCEffectEvapLate(),kind=dp), &
+                GetCrop_Tbase(), GetCrop_Tupper(), GetSimulParam_Tmin(), &
+                GetSimulParam_Tmax(), GetCrop_GDtranspLow(), GetCO2i(), &
+                GetCrop_ModeCycle(), .true.))
+        call SetSumKcTopStress( GetSumKcTop() * GetFracBiomassPotSF())
+    else
+        call SetSumKcTop(undef_int)
+        call SetSumKcTopStress(undef_int)
+    endif
     call SetSumKci(0._dp)
 
     ! 7. weed infestation and self-thinning of herbaceous perennial forage crops

--- a/src/run.f90
+++ b/src/run.f90
@@ -14,6 +14,7 @@ use ac_global, only:    AdjustSizeCompartments, &
                         GetCrop_GDDaysToHIo, &
                         GetCropFileSet, &
                         GetOut8Irri, &
+                        GetSimulation_Germinate, &
                         CompartmentIndividual, &
                         CompleteCropDescription, &
                         datatype_daily, &
@@ -577,6 +578,7 @@ integer(int32) :: IrriInterval
 integer(int32) :: Tadj, GDDTadj
 integer(int32) :: DayLastCut,NrCut,SumInterval
 integer(int32)  :: PreviousStressLevel, StressSFadjNEW
+integer(int32) :: RepeatToDay
 
 real(dp) :: Bin
 real(dp) :: Bout
@@ -2244,6 +2246,18 @@ subroutine SetDayNri(DayNri_in)
     DayNri = DayNri_in
 end subroutine SetDayNri
 
+
+integer(int32) function GetRepeatToDay()
+
+    GetRepeatToDay = RepeatToDay
+end function GetRepeatToDay
+
+
+subroutine SetRepeatToDay(RepeatToDay_in)
+    integer(int32), intent(in) :: RepeatToDay_in
+
+    RepeatToDay = RepeatToDay_in
+end subroutine SetRepeatToDay
 
 ! EToDataSet
 
@@ -7316,6 +7330,12 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
         call GetPotValSF((VirtualTimeCC+GetSimulation_DelayedDays() + 1), &
                SumGDDAdjCC, PotValSF)
     end if
+    ! Adjust crop cycle and simulation period to delayed days after germination
+    if ((GetSimulation_DelayedDays() > 0) .and. (GetSimulation_Germinate() .eqv. .true.)) then
+        call ResetCropAndSimulationPeriod(GetDayNri());
+        call SetRepeatToDay(GetSimulation_ToDayNr());
+    end if
+
     ! 14.d Print ---------------------------------------
     if (GetOutputAggregate() > 0) then
         call CheckForPrint(GetTheProjectFile())
@@ -7831,7 +7851,6 @@ end subroutine WriteIrrInfo
 
 subroutine FileManagement()
 
-    integer(int32) :: RepeatToDay
     real(dp) :: WPi
     logical :: HarvestNow
 

--- a/src/simul.f90
+++ b/src/simul.f90
@@ -668,7 +668,7 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
         WPunlim = WPi       ! no water stress, no fertiltiy stress
         if (GetSimulation_EffectStress_RedWP() > 0._dp) then ! Reductions are zero if no fertility stress
             ! water stress and fertility stress
-            if ((SumKci/real(SumKcTopStress, dp)) < 1._dp) then
+            if ((SumKci/SumKcTopStress) < (1._dp-epsilon(0._dp))) then
                 if (ETo > 0._dp) then
                     SumKci = SumKci + Tact/ETo
                 end if

--- a/src/startunit.F90
+++ b/src/startunit.F90
@@ -702,11 +702,11 @@ subroutine InitializeProject(iproject, TheProjectFile, TheProjectType)
                 write(tempstring, '(4a)') '               Field Management (MAN), '
                 call fProjects_write(trim(tempstring))
             end if
-            if (.not. FileOK%GroundWater_Filename) then
+            if (.not. FileOK%Soil_Filename) then
                 write(tempstring, '(4a)') '               Soil profile (SOL), '
                 call fProjects_write(trim(tempstring))
             end if
-            if (.not. FileOK%Soil_Filename) then
+            if (.not. FileOK%GroundWater_Filename) then
                 write(tempstring, '(4a)') '               Groundwater (GWT), '
                 call fProjects_write(trim(tempstring))
             end if


### PR DESCRIPTION
This PR includes three bug fixes:

(1) Bug in case of uncalibrated fertility and salinity stress: The simulation failed when requesting the calculation of the net irrigation requirement and using an uncalibrated crop for fertility stress.

(2) Bug related to delayed germination due to dry soil (standalone only): 
If the soil water content in the top soil is too low, germination is delayed until the soil water content rises above a threshold, as a result of rain and/or irrigation. In Version 7.0, not only (i) the start of the growing cycle is shifted, but also (ii) the length of the growing cycle is adjusted to the thermal regime of the shifted growing cycle, and (iii) the simulation period is extended so that its end coincides with the adjusted date of maturity.
This was implemented in the GUI V7.0, but the corresponding update in the StandAlone was incomplete

(3) Bug in checking of presence in input files, a wrong error message was printed.

Comparison against GUI output for specific test cases for which these errors occurred approved by Dirk.
